### PR TITLE
Add toc-org-skip-pre-toc-headings option

### DIFF
--- a/toc-org.el
+++ b/toc-org.el
@@ -80,6 +80,10 @@ and their subheadings (one and two stars)."
 the TOC links (even if the style is different from org)."
   :group 'toc-org)
 
+(defcustom toc-org-skip-pre-toc-headings nil
+  "Leave headings out of the TOC that occur before the TOC itself."
+  :group 'toc-org :type 'boolean)
+
 (defvar-local toc-org-hrefify-hash nil
   "Buffer local hash-table that is used to enable links
 opening. The keys are hrefified headings, the values are original
@@ -100,7 +104,10 @@ tags."
       (goto-char (point-min))
       (re-search-forward toc-org-toc-org-regexp nil t)
       (beginning-of-line)
-      (delete-region (point) (progn (forward-line 1) (point)))
+      (delete-region (if toc-org-skip-pre-toc-headings
+                         (point-min)
+                       (point))
+                     (progn (forward-line 1) (point)))
 
       ;; strip states
       (goto-char (point-min))


### PR DESCRIPTION
As discussed in #14.  I know you said you don't like the idea, but since it turned out to be such a simple patch, I decided to go ahead and send a PR.  I tested it and it works great, and it's off by default, so...  :)
