### PR TITLE
Delete trailing whitespaces from links

### DIFF
--- a/toc-org.el
+++ b/toc-org.el
@@ -290,6 +290,9 @@ each heading into a link."
             (skip-chars-forward " ")
             (insert "- ")
 
+	    (save-excursion
+	      (delete-trailing-whitespace (point) (line-end-position)))
+
             (let* ((beg (point))
                    (end (line-end-position))
                    (heading (buffer-substring-no-properties


### PR DESCRIPTION
It happens when headings has tags.  toc-org keep spaces and tabs between
the end of  the heading and the  beginning of the tag to  format the toc
links.

thanks