### PR TITLE
Use `delete-region` instead of kill-line while creating the TOC

### DIFF
--- a/toc-org.el
+++ b/toc-org.el
@@ -302,7 +302,7 @@ each heading into a link."
                (toc-org-format-visible-link
                 (buffer-substring-no-properties
                  (point) (line-end-position))))
-              (kill-line)
+              (delete-region (point) (line-end-position))
               (insert "]]")
 
               ;; maintain the hash table, if provided


### PR DESCRIPTION
`kill-line` adds the deleted text to the kill ring, polluting it. `delete-region` avoids this issue.