### PR TITLE
Support :noexport: and :noexport_children: tags

### DIFF
--- a/README.org
+++ b/README.org
@@ -18,6 +18,7 @@ name conflict with one of the org contrib modules.
  - [[#use][Use]]
    - [[#follow-links][Follow links]]
    - [[#shortcut-for-toc-tag][Shortcut for TOC tag]]
+   - [[#exclude-headings][Exclude headings]]
  - [[#different-href-styles][Different href styles]]
  - [[#example][Example]]
 
@@ -90,6 +91,10 @@ In your emacs' setup, you can bind a tag =:TOC:= to a binding =T=:
 #+END_SRC
 
 Now =C-c C-q T RET= and you are done putting the =:TOC:= entry.
+
+** Exclude headings
+
+Headings tagged =:noexport:= will be excluded from the TOC.  Headings tagged =:noexport_children:= will have their children excluded from the TOC.
 
 * Different href styles
 

--- a/toc-org.el
+++ b/toc-org.el
@@ -105,6 +105,7 @@ auxiliary text."
                   (point-min) (point-max)))
         (leave-states-p nil))
     (with-temp-buffer
+      (org-mode)
       (insert content)
 
       ;; set leave-states-p variable
@@ -141,6 +142,22 @@ auxiliary text."
       (goto-char (point-min))
       (while (re-search-forward toc-org-priorities-regexp nil t)
         (replace-match "" nil nil nil 1))
+
+      ;; Remove headings with :noexport: tag
+      (goto-char (point-min))
+      (while (re-search-forward org-complex-heading-regexp nil t)
+        (let ((tags (match-string 5)))
+          (when (and tags
+                     (string-match ":noexport:" tags))
+            (org-cut-subtree))))
+
+      ;; Remove headings below :noexport_children: tag
+      (goto-char (point-min))
+      (while (re-search-forward org-complex-heading-regexp nil t)
+        (let ((tags (match-string 5)))
+          (when (and tags
+                     (string-match ":noexport_children:" tags))
+            (delete-region (line-end-position) (1- (org-element-property :end (org-element-at-point)))))))
 
       ;; strip tags
       ;; TODO :export: and :noexport: tags semantic should be probably


### PR DESCRIPTION
As mentioned in #14, this allows the user to exclude certain headings from the TOC.  `:noexport:` headings will not appear in the TOC, and children headings of `:noexport_children` headings will not appear in the TOC.

For example, I want my changelog heading to appear in the TOC, but not each version mentioned beneath it, so I mark the changelog heading `:noexport_children:`.

Thanks for your work on toc-org.  :)