### PR TITLE
Fixes for NonGNU ELPA

### DIFF
--- a/toc-org-test.el
+++ b/toc-org-test.el
@@ -1,3 +1,20 @@
+;; Copyright (C) 2017 Sergei Nosov
+
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation; either version 2, or (at
+;; your option) any later version.
+
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+;; Boston, MA 02111-1307, USA.
+
 (require 'ert)
 (require 'toc-org)
 

--- a/toc-org.el
+++ b/toc-org.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2014 Sergei Nosov
 
 ;; Author: Sergei Nosov <sergei.nosov [at] gmail.com>
-;; Version: 1.0
+;; Version: 1.1
 ;; Keywords: org-mode org-toc toc-org org toc table of contents
 ;; URL: https://github.com/snosov1/toc-org
 


### PR DESCRIPTION
Hi!

I am investigating if we could add this package to [NonGNU ELPA](http://elpa.nongnu.org/) (see link), a new Emacs Lisp package archive that will be enabled by default in Emacs 28. This means that users of that version or later will be able to install this package without any configuration: they can just run `M-x list-packages` and install it out of the box. We hope that this will improve Emacs and help bring new users to this package and others.

This pull request fixes two issues:

1. NonGNU ELPA has a requirement that all files to have a clear statement of its license and copyright status.

2. The main difference between NonGNU ELPA and MELPA is that only tagged versions of packages are released. This means that a new release will be automatically when you bump the "Version" commentary header in this repository. You can bump the package version (thereby releasing a new version) at your convenience.

Please let me know if you have any questions about NonGNU ELPA.

Thanks!