### PR TITLE
Added a new command that views the table of content in a dedicated side window

### DIFF
--- a/README.org
+++ b/README.org
@@ -105,7 +105,6 @@ command again will close it.
 Inside the TOC window:
 - Use ~C-c C-o~ (~org-open-at-point~) to jump to the corresponding heading in
   the source buffer.
-- Press ~q~ to quickly close the window.
 
 You can customize the appearance by setting these variables:
 - ~toc-org-side-window-side~: Where to display the window (~'left~,
@@ -114,6 +113,11 @@ You can customize the appearance by setting these variables:
 - Use an *integer* for a fixed number of columns or lines.
 - Use a *float* (between 0.0 and 1.0) to set it as a *percentage* of the
   frame size (e.g., ~0.3~ for 30%).
+
+It's recommended to map ~toc-org-show-toc-window~ to a shortcut.
+ - Example:
+  ~(with-eval-after-load 'org
+    (define-key org-mode-map (kbd "C-c t") #'toc-org-show-toc-window))~
 
 ** Follow links
 

--- a/README.org
+++ b/README.org
@@ -18,6 +18,7 @@ name conflict with one of the org contrib modules.
   - [[#via-packageel][via package.el]]
   - [[#manual][Manual]]
 - [[#use][Use]]
+  - [[#toc-side-window][TOC Side Window]]
   - [[#follow-links][Follow links]]
   - [[#exclude-headings][Exclude headings]]
   - [[#quote-table-of-contents][Quote table of contents]]
@@ -90,6 +91,27 @@ It's possible to set the default values of max depth and hrefify function with
 you do this outside of the org file itself, then you can face conflicts if you 
 work on the same file collaboratively with someone else, as your default configs 
 can vary.
+
+** TOC Side Window
+
+You can display the table of contents in a dedicated side window for easier
+navigation using: ~M-x toc-org-show-toc-window~
+
+This command works as a *toggle*: if the window is already open, calling the
+command again will close it.
+
+Inside the TOC window:
+- Use ~C-c C-o~ (~org-open-at-point~) to jump to the corresponding heading in
+  the source buffer.
+- Press ~q~ to quickly close the window.
+
+You can customize the appearance by setting these variables:
+- ~toc-org-side-window-side~: Where to display the window (~'left~,
+  ~'right~,~'top~, or ~'bottom~).
+- ~toc-org-side-window-size~: Controls the width or height of the window.
+- Use an *integer* for a fixed number of columns or lines.
+- Use a *float* (between 0.0 and 1.0) to set it as a *percentage* of the
+  frame size (e.g., ~0.3~ for 30%).
 
 ** Follow links
 

--- a/README.org
+++ b/README.org
@@ -21,7 +21,7 @@ name conflict with one of the org contrib modules.
   - [[#follow-links][Follow links]]
   - [[#exclude-headings][Exclude headings]]
   - [[#quote-table-of-contents][Quote table of contents]]
-  - [[#navigation-window][Navigation window]]
+  - [[#navigation-pane][Navigation pane]]
   - [[#shortcut-for-toc-tag][Shortcut for TOC tag]]
 - [[#markdown-support][Markdown support]]
 - [[#different-href-styles][Different href styles]]
@@ -121,16 +121,16 @@ quote block (i.e. =#+BEGIN_QUOTE= / =#+END_QUOTE=). In that case, GitHub, for
 example, will add a vertical line to the left of the TOC that makes it distinct
 from the main text. To do this, just add a =:QUOTE:= tag to the TOC heading.
 
-** Navigation window
+** Navigation pane
 
 You can display the table of contents in a dedicated side window for easier
-navigation using: =M-x toc-org-navigation-window= (mapped to =C-c t=). This
+navigation using: =M-x toc-org-navigation-pane= (mapped to =C-c t=). This
 command works as a *toggle*: if the window is already open, calling the command
 again will close it.
 
 The buffer is read-only with single-letter shortcuts =n=, =p=, =f=, =b= for
 navigation; =k= to close; and =RET= to follow a link.  See =C-h f
-toc-org-navigation-window= for customization options.
+toc-org-navigation-pane= for customization options.
 
 ** Shortcut for TOC tag
 

--- a/README.org
+++ b/README.org
@@ -128,17 +128,9 @@ navigation using: =M-x toc-org-navigation-window= (mapped to =C-c t=). This
 command works as a *toggle*: if the window is already open, calling the command
 again will close it.
 
-The buffer is read-only and you can use single-letter shortcuts, like, =n=, =p=,
- =f=, =b= for navigation; =k= for killing it and =C-m=/=ENTER= for following the
- links.
-
-You can customize the appearance by setting these variables:
-- =toc-org-side-window-side=: Where to display the window (='left=,
-  ='right=, ='top=, or ='bottom=).
-- =toc-org-side-window-size~: Controls the width or height of the window.
-- Use an *integer* for a fixed number of columns or lines.
-- Use a *float* (between 0.0 and 1.0) to set it as a *percentage* of the
-  frame size (e.g., ~0.3~ for 30%).
+The buffer is read-only with single-letter shortcuts =n=, =p=, =f=, =b= for
+navigation; =k= to close; and =RET= to follow a link.  See =C-h f
+toc-org-navigation-window= for customization options.
 
 ** Shortcut for TOC tag
 

--- a/README.org
+++ b/README.org
@@ -18,10 +18,10 @@ name conflict with one of the org contrib modules.
   - [[#via-packageel][via package.el]]
   - [[#manual][Manual]]
 - [[#use][Use]]
-  - [[#toc-side-window][TOC Side Window]]
   - [[#follow-links][Follow links]]
   - [[#exclude-headings][Exclude headings]]
   - [[#quote-table-of-contents][Quote table of contents]]
+  - [[#navigation-window][Navigation window]]
   - [[#shortcut-for-toc-tag][Shortcut for TOC tag]]
 - [[#markdown-support][Markdown support]]
 - [[#different-href-styles][Different href styles]]
@@ -88,36 +88,9 @@ You can also use =@= as separator, instead of =_=.
 
 It's possible to set the default values of max depth and hrefify function with
 =toc-org-max-depth= and =toc-org-hrefify-default= variables. But, note, that if
-you do this outside of the org file itself, then you can face conflicts if you 
-work on the same file collaboratively with someone else, as your default configs 
+you do this outside of the org file itself, then you can face conflicts if you
+work on the same file collaboratively with someone else, as your default configs
 can vary.
-
-** TOC Side Window
-
-[[https://github-production-user-asset-6210df.s3.amazonaws.com/215027645/591403334-d0431bc4-458b-477b-b680-f77a34014160.gif?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20260512%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20260512T232232Z&X-Amz-Expires=300&X-Amz-Signature=5e986cd3a4efc113d4adf22447fee83831f5cacc0babdaef17d463bcd42b0b06&X-Amz-SignedHeaders=host&response-content-type=image%2Fgif]]
-
-You can display the table of contents in a dedicated side window for easier
-navigation using: ~M-x toc-org-show-toc-window~
-
-This command works as a *toggle*: if the window is already open, calling the
-command again will close it.
-
-Inside the TOC window:
-- Use ~C-c C-o~ (~org-open-at-point~) to jump to the corresponding heading in
-  the source buffer.
-
-You can customize the appearance by setting these variables:
-- ~toc-org-side-window-side~: Where to display the window (~'left~,
-  ~'right~,~'top~, or ~'bottom~).
-- ~toc-org-side-window-size~: Controls the width or height of the window.
-- Use an *integer* for a fixed number of columns or lines.
-- Use a *float* (between 0.0 and 1.0) to set it as a *percentage* of the
-  frame size (e.g., ~0.3~ for 30%).
-
-It's recommended to map ~toc-org-show-toc-window~ to a shortcut.
- - Example:
-  ~(with-eval-after-load 'org
-    (define-key org-mode-map (kbd "C-c t") #'toc-org-show-toc-window))~
 
 ** Follow links
 
@@ -147,6 +120,25 @@ For presentation purposes, you might want to put the table of contents in a
 quote block (i.e. =#+BEGIN_QUOTE= / =#+END_QUOTE=). In that case, GitHub, for
 example, will add a vertical line to the left of the TOC that makes it distinct
 from the main text. To do this, just add a =:QUOTE:= tag to the TOC heading.
+
+** Navigation window
+
+You can display the table of contents in a dedicated side window for easier
+navigation using: =M-x toc-org-show-toc-window= (mapped to =C-c t=). This
+command works as a *toggle*: if the window is already open, calling the command
+again will close it.
+
+The buffer is read-only and you can use single-letter shortcuts, like, =n=, =p=,
+ =f=, =b= for navigation; =k= for killing it and =C-m=/=ENTER= for following the
+ links.
+
+You can customize the appearance by setting these variables:
+- =toc-org-side-window-side=: Where to display the window (='left=,
+  ='right=, ='top=, or ='bottom=).
+- =toc-org-side-window-size~: Controls the width or height of the window.
+- Use an *integer* for a fixed number of columns or lines.
+- Use a *float* (between 0.0 and 1.0) to set it as a *percentage* of the
+  frame size (e.g., ~0.3~ for 30%).
 
 ** Shortcut for TOC tag
 

--- a/README.org
+++ b/README.org
@@ -124,7 +124,7 @@ from the main text. To do this, just add a =:QUOTE:= tag to the TOC heading.
 ** Navigation window
 
 You can display the table of contents in a dedicated side window for easier
-navigation using: =M-x toc-org-show-toc-window= (mapped to =C-c t=). This
+navigation using: =M-x toc-org-navigation-window= (mapped to =C-c t=). This
 command works as a *toggle*: if the window is already open, calling the command
 again will close it.
 

--- a/README.org
+++ b/README.org
@@ -94,6 +94,8 @@ can vary.
 
 ** TOC Side Window
 
+[[https://github-production-user-asset-6210df.s3.amazonaws.com/215027645/591403334-d0431bc4-458b-477b-b680-f77a34014160.gif?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20260512%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20260512T232232Z&X-Amz-Expires=300&X-Amz-Signature=5e986cd3a4efc113d4adf22447fee83831f5cacc0babdaef17d463bcd42b0b06&X-Amz-SignedHeaders=host&response-content-type=image%2Fgif]]
+
 You can display the table of contents in a dedicated side window for easier
 navigation using: ~M-x toc-org-show-toc-window~
 

--- a/toc-org-test.el
+++ b/toc-org-test.el
@@ -430,3 +430,38 @@ producing \"Selecting deleted buffer\"."
       (when (get-buffer toc-org-navigation-pane-buffer-name) (kill-buffer (get-buffer toc-org-navigation-pane-buffer-name)))
       (kill-buffer buf)
       (delete-file tmpfile))))
+
+(ert-deftest test-toc-org-nav-next-and-prev ()
+  "M-n / M-p move the pane point and update the source window position."
+  (when (get-buffer toc-org-navigation-pane-buffer-name)
+    (kill-buffer toc-org-navigation-pane-buffer-name))
+  (let* ((tmpfile (make-temp-file "toc-org-test" nil ".org"))
+         (buf (find-file-noselect tmpfile))
+         (win (selected-window)))
+    (unwind-protect
+        (with-current-buffer buf
+          (insert "* First\n* Second\n* Third\n")
+          (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-pane)
+          (cl-letf (((symbol-function 'display-buffer) #'ignore)
+                    ((symbol-function 'select-window)  #'ignore))
+            (toc-org-navigation-pane))
+          (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-pane)
+          (let ((nav-buf (get-buffer toc-org-navigation-pane-buffer-name)))
+            (set-window-buffer win buf)
+            (cl-letf (((symbol-function 'get-buffer-window)
+                       (lambda (b &rest _) (when (eq b buf) win))))
+              (with-current-buffer nav-buf
+                (goto-char (point-min))
+                (toc-org--nav-next)
+                (should (= (line-number-at-pos) 2)))
+              ;; window-point is a position in buf — check it in buf's context
+              (should (= (with-current-buffer buf (line-number-at-pos (window-point win))) 2))
+              (with-current-buffer nav-buf
+                (toc-org--nav-prev)
+                (should (= (line-number-at-pos) 1)))
+              (should (= (with-current-buffer buf (line-number-at-pos (window-point win))) 1)))))
+      (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-pane)
+      (when (get-buffer toc-org-navigation-pane-buffer-name)
+        (kill-buffer (get-buffer toc-org-navigation-pane-buffer-name)))
+      (kill-buffer buf)
+      (delete-file tmpfile))))

--- a/toc-org-test.el
+++ b/toc-org-test.el
@@ -305,14 +305,14 @@ silently dropping the first heading."
     (unwind-protect
         (with-current-buffer buf
           (insert "* First\n* Second\n")
-          (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
+          (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-pane)
           (cl-letf (((symbol-function 'display-buffer) #'ignore)
                     ((symbol-function 'select-window)  #'ignore))
             (toc-org-navigation-pane))
           (with-current-buffer (get-buffer toc-org-navigation-pane-buffer-name)
             (should (string-match-p "First" (buffer-string)))
             (should (string-match-p "Second" (buffer-string)))))
-      (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
+      (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-pane)
       (when (get-buffer toc-org-navigation-pane-buffer-name) (kill-buffer (get-buffer toc-org-navigation-pane-buffer-name)))
       (kill-buffer buf)
       (delete-file tmpfile))))
@@ -330,7 +330,7 @@ window-point path and always resetting point to the beginning."
     (unwind-protect
         (with-current-buffer buf
           (insert "* Heading 1\n* Heading 2\n* Heading 3\n")
-          (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
+          (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-pane)
           (cl-letf (((symbol-function 'display-buffer) #'ignore)
                     ((symbol-function 'select-window)  #'ignore))
             (toc-org-navigation-pane))
@@ -345,7 +345,7 @@ window-point path and always resetting point to the beginning."
                      (lambda (_ pos) (setq captured-set-point pos))))
             (toc-org--refresh-navigation-pane))
           (should (eql captured-set-point 5)))
-      (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
+      (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-pane)
       (when (get-buffer toc-org-navigation-pane-buffer-name)
         (kill-buffer (get-buffer toc-org-navigation-pane-buffer-name)))
       (kill-buffer buf)
@@ -379,12 +379,12 @@ window-point path and always resetting point to the beginning."
     (unwind-protect
         (with-current-buffer buf
           (insert "* Heading 1\n* Heading 2\n")
-          (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
+          (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-pane)
           (cl-letf (((symbol-function 'display-buffer) #'ignore)
                     ((symbol-function 'select-window)  #'ignore))
             (toc-org-navigation-pane))
-          (should (memq #'toc-org--close-toc-window buffer-list-update-hook)))
-      (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
+          (should (memq #'toc-org--close-toc-pane buffer-list-update-hook)))
+      (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-pane)
       (when (get-buffer toc-org-navigation-pane-buffer-name) (kill-buffer (get-buffer toc-org-navigation-pane-buffer-name)))
       (kill-buffer buf)
       (delete-file tmpfile))))
@@ -396,21 +396,21 @@ window-point path and always resetting point to the beginning."
     (unwind-protect
         (with-current-buffer buf
           (insert "* Heading 1\n* Heading 2\n")
-          (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
+          (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-pane)
           (cl-letf (((symbol-function 'display-buffer) #'ignore)
                     ((symbol-function 'select-window)  #'ignore))
             (toc-org-navigation-pane))
           (when toc-org--toc-buffer (kill-buffer toc-org--toc-buffer))
-          (toc-org--close-toc-window)
-          (should (null (memq #'toc-org--close-toc-window buffer-list-update-hook))))
-      (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
+          (toc-org--close-toc-pane)
+          (should (null (memq #'toc-org--close-toc-pane buffer-list-update-hook))))
+      (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-pane)
       (when (get-buffer toc-org-navigation-pane-buffer-name) (kill-buffer (get-buffer toc-org-navigation-pane-buffer-name)))
       (kill-buffer buf)
       (delete-file tmpfile))))
 
 (ert-deftest test-toc-org-navigation-pane-no-error-on-buffer-switch ()
   "Switching away from the source buffer closes *org-toc* without error.
-Regression: toc-org--close-toc-window iterated buffer-list and killed
+Regression: toc-org--close-toc-pane iterated buffer-list and killed
 *org-toc* mid-loop, then tried to with-current-buffer the now-dead entry,
 producing \"Selecting deleted buffer\"."
   (let* ((tmpfile (make-temp-file "toc-org-test" nil ".org"))
@@ -418,15 +418,15 @@ producing \"Selecting deleted buffer\"."
     (unwind-protect
         (with-current-buffer buf
           (insert "* Heading 1\n* Heading 2\n")
-          (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
+          (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-pane)
           (cl-letf (((symbol-function 'display-buffer) #'ignore)
                     ((symbol-function 'select-window)  #'ignore))
             (toc-org-navigation-pane))
           ;; TOC buffer is still alive; hook kills it mid-iteration — must not error
           (should (buffer-live-p toc-org--toc-buffer))
-          (should-not (eq (toc-org--close-toc-window) 'error))
+          (should-not (eq (toc-org--close-toc-pane) 'error))
           (should (null (get-buffer toc-org-navigation-pane-buffer-name))))
-      (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
+      (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-pane)
       (when (get-buffer toc-org-navigation-pane-buffer-name) (kill-buffer (get-buffer toc-org-navigation-pane-buffer-name)))
       (kill-buffer buf)
       (delete-file tmpfile))))

--- a/toc-org-test.el
+++ b/toc-org-test.el
@@ -16,6 +16,7 @@
 ;; Boston, MA 02111-1307, USA.
 
 (require 'ert)
+(require 'cl-lib)
 (require 'toc-org)
 
 (ert-deftest test-toc-org-raw-toc ()
@@ -290,3 +291,142 @@
      (concat beg "<-- :TOC: -->")
      "# About\n:TOC:\n drawer\n:END:\n\ntoc-org is a utility to have an up-to-date table of contents in the\norg files without exporting (useful primarily for readme files on\nGitHub).\n\nIt is similar to the [[https://github.com/ardumont/markdown-toc][markdown-toc]] package, but works for org files.\n:TOC:\n  drawer\n:END:\n# Hello\n## Good-bye ##\n### Salut\n# Table of Contents                                                     <-- :TOC: -->\n- [About](#about)\n- [Hello](#hello)\n  - [Good-bye](#good-bye)\n")
     ))
+
+;; Tests for toc-org-navigation-window
+
+(ert-deftest test-toc-org-navigation-window-first-heading-shown ()
+  "Navigation window shows all headings including the first one.
+Regression: toc-org-raw-toc always deleted the line at point after the
+search for the :toc: heading, even when no :toc: heading was present,
+silently dropping the first heading."
+  (when (get-buffer toc-org-navigation-window-buffer-name) (kill-buffer toc-org-navigation-window-buffer-name))
+  (let* ((tmpfile (make-temp-file "toc-org-test" nil ".org"))
+         (buf (find-file-noselect tmpfile)))
+    (unwind-protect
+        (with-current-buffer buf
+          (insert "* First\n* Second\n")
+          (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
+          (cl-letf (((symbol-function 'display-buffer) #'ignore)
+                    ((symbol-function 'select-window)  #'ignore))
+            (toc-org-navigation-window))
+          (with-current-buffer (get-buffer toc-org-navigation-window-buffer-name)
+            (should (string-match-p "First" (buffer-string)))
+            (should (string-match-p "Second" (buffer-string)))))
+      (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
+      (when (get-buffer toc-org-navigation-window-buffer-name) (kill-buffer (get-buffer toc-org-navigation-window-buffer-name)))
+      (kill-buffer buf)
+      (delete-file tmpfile))))
+
+(ert-deftest test-toc-org-navigation-window-point-preserved ()
+  "Navigation window restores window-point on refresh, not reset to beginning.
+Regression: toc-org--toc-buffer is defvar-local, so referencing it inside
+with-current-buffer (where the TOC buffer is current) yields nil instead of
+the TOC buffer.  get-buffer-window then received nil, skipping the
+window-point path and always resetting point to the beginning."
+  (let* ((tmpfile (make-temp-file "toc-org-test" nil ".org"))
+         (buf (find-file-noselect tmpfile))
+         (fake-win (cons 'fake 'window))
+         captured-set-point)
+    (unwind-protect
+        (with-current-buffer buf
+          (insert "* Heading 1\n* Heading 2\n* Heading 3\n")
+          (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
+          (cl-letf (((symbol-function 'display-buffer) #'ignore)
+                    ((symbol-function 'select-window)  #'ignore))
+            (toc-org-navigation-window))
+          ;; Mock get-buffer-window to return fake-win only for a real buffer
+          ;; object — nil (the value toc-org--toc-buffer has inside
+          ;; with-current-buffer) would return nil, skipping set-window-point.
+          (cl-letf (((symbol-function 'get-buffer-window)
+                     (lambda (b &rest _) (when (bufferp b) fake-win)))
+                    ((symbol-function 'window-point)
+                     (lambda (_) 5))
+                    ((symbol-function 'set-window-point)
+                     (lambda (_ pos) (setq captured-set-point pos))))
+            (toc-org--refresh-navigation-window))
+          (should (eql captured-set-point 5)))
+      (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
+      (when (get-buffer toc-org-navigation-window-buffer-name)
+        (kill-buffer (get-buffer toc-org-navigation-window-buffer-name)))
+      (kill-buffer buf)
+      (delete-file tmpfile))))
+
+(ert-deftest test-toc-org-navigation-window-non-file-buffer ()
+  "Navigation window leaves no *org-toc* buffer when buffer is not visiting a file."
+  (when (get-buffer toc-org-navigation-window-buffer-name) (kill-buffer toc-org-navigation-window-buffer-name))
+  (with-temp-buffer
+    (org-mode)
+    (insert "* Heading 1\n* Heading 2\n")
+    (toc-org-navigation-window))
+  (should (null (get-buffer toc-org-navigation-window-buffer-name))))
+
+(ert-deftest test-toc-org-navigation-window-no-headings-no-leak ()
+  "Navigation window leaves no *org-toc* buffer when buffer has no headings."
+  (when (get-buffer toc-org-navigation-window-buffer-name) (kill-buffer toc-org-navigation-window-buffer-name))
+  (let* ((tmpfile (make-temp-file "toc-org-test" nil ".org"))
+         (buf (find-file-noselect tmpfile)))
+    (unwind-protect
+        (with-current-buffer buf
+          (toc-org-navigation-window)
+          (should (null (get-buffer toc-org-navigation-window-buffer-name))))
+      (kill-buffer buf)
+      (delete-file tmpfile))))
+
+(ert-deftest test-toc-org-navigation-window-hook-added ()
+  "buffer-list-update-hook is added when the navigation window is opened."
+  (let* ((tmpfile (make-temp-file "toc-org-test" nil ".org"))
+         (buf (find-file-noselect tmpfile)))
+    (unwind-protect
+        (with-current-buffer buf
+          (insert "* Heading 1\n* Heading 2\n")
+          (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
+          (cl-letf (((symbol-function 'display-buffer) #'ignore)
+                    ((symbol-function 'select-window)  #'ignore))
+            (toc-org-navigation-window))
+          (should (memq #'toc-org--close-toc-window buffer-list-update-hook)))
+      (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
+      (when (get-buffer toc-org-navigation-window-buffer-name) (kill-buffer (get-buffer toc-org-navigation-window-buffer-name)))
+      (kill-buffer buf)
+      (delete-file tmpfile))))
+
+(ert-deftest test-toc-org-navigation-window-hook-removed ()
+  "buffer-list-update-hook is removed once all TOC windows are closed."
+  (let* ((tmpfile (make-temp-file "toc-org-test" nil ".org"))
+         (buf (find-file-noselect tmpfile)))
+    (unwind-protect
+        (with-current-buffer buf
+          (insert "* Heading 1\n* Heading 2\n")
+          (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
+          (cl-letf (((symbol-function 'display-buffer) #'ignore)
+                    ((symbol-function 'select-window)  #'ignore))
+            (toc-org-navigation-window))
+          (when toc-org--toc-buffer (kill-buffer toc-org--toc-buffer))
+          (toc-org--close-toc-window)
+          (should (null (memq #'toc-org--close-toc-window buffer-list-update-hook))))
+      (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
+      (when (get-buffer toc-org-navigation-window-buffer-name) (kill-buffer (get-buffer toc-org-navigation-window-buffer-name)))
+      (kill-buffer buf)
+      (delete-file tmpfile))))
+
+(ert-deftest test-toc-org-navigation-window-no-error-on-buffer-switch ()
+  "Switching away from the source buffer closes *org-toc* without error.
+Regression: toc-org--close-toc-window iterated buffer-list and killed
+*org-toc* mid-loop, then tried to with-current-buffer the now-dead entry,
+producing \"Selecting deleted buffer\"."
+  (let* ((tmpfile (make-temp-file "toc-org-test" nil ".org"))
+         (buf (find-file-noselect tmpfile)))
+    (unwind-protect
+        (with-current-buffer buf
+          (insert "* Heading 1\n* Heading 2\n")
+          (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
+          (cl-letf (((symbol-function 'display-buffer) #'ignore)
+                    ((symbol-function 'select-window)  #'ignore))
+            (toc-org-navigation-window))
+          ;; TOC buffer is still alive; hook kills it mid-iteration — must not error
+          (should (buffer-live-p toc-org--toc-buffer))
+          (should-not (eq (toc-org--close-toc-window) 'error))
+          (should (null (get-buffer toc-org-navigation-window-buffer-name))))
+      (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
+      (when (get-buffer toc-org-navigation-window-buffer-name) (kill-buffer (get-buffer toc-org-navigation-window-buffer-name)))
+      (kill-buffer buf)
+      (delete-file tmpfile))))

--- a/toc-org-test.el
+++ b/toc-org-test.el
@@ -292,14 +292,14 @@
      "# About\n:TOC:\n drawer\n:END:\n\ntoc-org is a utility to have an up-to-date table of contents in the\norg files without exporting (useful primarily for readme files on\nGitHub).\n\nIt is similar to the [[https://github.com/ardumont/markdown-toc][markdown-toc]] package, but works for org files.\n:TOC:\n  drawer\n:END:\n# Hello\n## Good-bye ##\n### Salut\n# Table of Contents                                                     <-- :TOC: -->\n- [About](#about)\n- [Hello](#hello)\n  - [Good-bye](#good-bye)\n")
     ))
 
-;; Tests for toc-org-navigation-window
+;; Tests for toc-org-navigation-pane
 
-(ert-deftest test-toc-org-navigation-window-first-heading-shown ()
-  "Navigation window shows all headings including the first one.
+(ert-deftest test-toc-org-navigation-pane-first-heading-shown ()
+  "Navigation pane shows all headings including the first one.
 Regression: toc-org-raw-toc always deleted the line at point after the
 search for the :toc: heading, even when no :toc: heading was present,
 silently dropping the first heading."
-  (when (get-buffer toc-org-navigation-window-buffer-name) (kill-buffer toc-org-navigation-window-buffer-name))
+  (when (get-buffer toc-org-navigation-pane-buffer-name) (kill-buffer toc-org-navigation-pane-buffer-name))
   (let* ((tmpfile (make-temp-file "toc-org-test" nil ".org"))
          (buf (find-file-noselect tmpfile)))
     (unwind-protect
@@ -308,17 +308,17 @@ silently dropping the first heading."
           (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
           (cl-letf (((symbol-function 'display-buffer) #'ignore)
                     ((symbol-function 'select-window)  #'ignore))
-            (toc-org-navigation-window))
-          (with-current-buffer (get-buffer toc-org-navigation-window-buffer-name)
+            (toc-org-navigation-pane))
+          (with-current-buffer (get-buffer toc-org-navigation-pane-buffer-name)
             (should (string-match-p "First" (buffer-string)))
             (should (string-match-p "Second" (buffer-string)))))
       (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
-      (when (get-buffer toc-org-navigation-window-buffer-name) (kill-buffer (get-buffer toc-org-navigation-window-buffer-name)))
+      (when (get-buffer toc-org-navigation-pane-buffer-name) (kill-buffer (get-buffer toc-org-navigation-pane-buffer-name)))
       (kill-buffer buf)
       (delete-file tmpfile))))
 
-(ert-deftest test-toc-org-navigation-window-point-preserved ()
-  "Navigation window restores window-point on refresh, not reset to beginning.
+(ert-deftest test-toc-org-navigation-pane-point-preserved ()
+  "Navigation pane restores window-point on refresh, not reset to beginning.
 Regression: toc-org--toc-buffer is defvar-local, so referencing it inside
 with-current-buffer (where the TOC buffer is current) yields nil instead of
 the TOC buffer.  get-buffer-window then received nil, skipping the
@@ -333,7 +333,7 @@ window-point path and always resetting point to the beginning."
           (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
           (cl-letf (((symbol-function 'display-buffer) #'ignore)
                     ((symbol-function 'select-window)  #'ignore))
-            (toc-org-navigation-window))
+            (toc-org-navigation-pane))
           ;; Mock get-buffer-window to return fake-win only for a real buffer
           ;; object — nil (the value toc-org--toc-buffer has inside
           ;; with-current-buffer) would return nil, skipping set-window-point.
@@ -343,37 +343,37 @@ window-point path and always resetting point to the beginning."
                      (lambda (_) 5))
                     ((symbol-function 'set-window-point)
                      (lambda (_ pos) (setq captured-set-point pos))))
-            (toc-org--refresh-navigation-window))
+            (toc-org--refresh-navigation-pane))
           (should (eql captured-set-point 5)))
       (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
-      (when (get-buffer toc-org-navigation-window-buffer-name)
-        (kill-buffer (get-buffer toc-org-navigation-window-buffer-name)))
+      (when (get-buffer toc-org-navigation-pane-buffer-name)
+        (kill-buffer (get-buffer toc-org-navigation-pane-buffer-name)))
       (kill-buffer buf)
       (delete-file tmpfile))))
 
-(ert-deftest test-toc-org-navigation-window-non-file-buffer ()
-  "Navigation window leaves no *org-toc* buffer when buffer is not visiting a file."
-  (when (get-buffer toc-org-navigation-window-buffer-name) (kill-buffer toc-org-navigation-window-buffer-name))
+(ert-deftest test-toc-org-navigation-pane-non-file-buffer ()
+  "Navigation pane leaves no *org-toc* buffer when buffer is not visiting a file."
+  (when (get-buffer toc-org-navigation-pane-buffer-name) (kill-buffer toc-org-navigation-pane-buffer-name))
   (with-temp-buffer
     (org-mode)
     (insert "* Heading 1\n* Heading 2\n")
-    (toc-org-navigation-window))
-  (should (null (get-buffer toc-org-navigation-window-buffer-name))))
+    (toc-org-navigation-pane))
+  (should (null (get-buffer toc-org-navigation-pane-buffer-name))))
 
-(ert-deftest test-toc-org-navigation-window-no-headings-no-leak ()
-  "Navigation window leaves no *org-toc* buffer when buffer has no headings."
-  (when (get-buffer toc-org-navigation-window-buffer-name) (kill-buffer toc-org-navigation-window-buffer-name))
+(ert-deftest test-toc-org-navigation-pane-no-headings-no-leak ()
+  "Navigation pane leaves no *org-toc* buffer when buffer has no headings."
+  (when (get-buffer toc-org-navigation-pane-buffer-name) (kill-buffer toc-org-navigation-pane-buffer-name))
   (let* ((tmpfile (make-temp-file "toc-org-test" nil ".org"))
          (buf (find-file-noselect tmpfile)))
     (unwind-protect
         (with-current-buffer buf
-          (toc-org-navigation-window)
-          (should (null (get-buffer toc-org-navigation-window-buffer-name))))
+          (toc-org-navigation-pane)
+          (should (null (get-buffer toc-org-navigation-pane-buffer-name))))
       (kill-buffer buf)
       (delete-file tmpfile))))
 
-(ert-deftest test-toc-org-navigation-window-hook-added ()
-  "buffer-list-update-hook is added when the navigation window is opened."
+(ert-deftest test-toc-org-navigation-pane-hook-added ()
+  "buffer-list-update-hook is added when the navigation pane is opened."
   (let* ((tmpfile (make-temp-file "toc-org-test" nil ".org"))
          (buf (find-file-noselect tmpfile)))
     (unwind-protect
@@ -382,14 +382,14 @@ window-point path and always resetting point to the beginning."
           (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
           (cl-letf (((symbol-function 'display-buffer) #'ignore)
                     ((symbol-function 'select-window)  #'ignore))
-            (toc-org-navigation-window))
+            (toc-org-navigation-pane))
           (should (memq #'toc-org--close-toc-window buffer-list-update-hook)))
       (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
-      (when (get-buffer toc-org-navigation-window-buffer-name) (kill-buffer (get-buffer toc-org-navigation-window-buffer-name)))
+      (when (get-buffer toc-org-navigation-pane-buffer-name) (kill-buffer (get-buffer toc-org-navigation-pane-buffer-name)))
       (kill-buffer buf)
       (delete-file tmpfile))))
 
-(ert-deftest test-toc-org-navigation-window-hook-removed ()
+(ert-deftest test-toc-org-navigation-pane-hook-removed ()
   "buffer-list-update-hook is removed once all TOC windows are closed."
   (let* ((tmpfile (make-temp-file "toc-org-test" nil ".org"))
          (buf (find-file-noselect tmpfile)))
@@ -399,16 +399,16 @@ window-point path and always resetting point to the beginning."
           (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
           (cl-letf (((symbol-function 'display-buffer) #'ignore)
                     ((symbol-function 'select-window)  #'ignore))
-            (toc-org-navigation-window))
+            (toc-org-navigation-pane))
           (when toc-org--toc-buffer (kill-buffer toc-org--toc-buffer))
           (toc-org--close-toc-window)
           (should (null (memq #'toc-org--close-toc-window buffer-list-update-hook))))
       (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
-      (when (get-buffer toc-org-navigation-window-buffer-name) (kill-buffer (get-buffer toc-org-navigation-window-buffer-name)))
+      (when (get-buffer toc-org-navigation-pane-buffer-name) (kill-buffer (get-buffer toc-org-navigation-pane-buffer-name)))
       (kill-buffer buf)
       (delete-file tmpfile))))
 
-(ert-deftest test-toc-org-navigation-window-no-error-on-buffer-switch ()
+(ert-deftest test-toc-org-navigation-pane-no-error-on-buffer-switch ()
   "Switching away from the source buffer closes *org-toc* without error.
 Regression: toc-org--close-toc-window iterated buffer-list and killed
 *org-toc* mid-loop, then tried to with-current-buffer the now-dead entry,
@@ -421,12 +421,12 @@ producing \"Selecting deleted buffer\"."
           (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
           (cl-letf (((symbol-function 'display-buffer) #'ignore)
                     ((symbol-function 'select-window)  #'ignore))
-            (toc-org-navigation-window))
+            (toc-org-navigation-pane))
           ;; TOC buffer is still alive; hook kills it mid-iteration — must not error
           (should (buffer-live-p toc-org--toc-buffer))
           (should-not (eq (toc-org--close-toc-window) 'error))
-          (should (null (get-buffer toc-org-navigation-window-buffer-name))))
+          (should (null (get-buffer toc-org-navigation-pane-buffer-name))))
       (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
-      (when (get-buffer toc-org-navigation-window-buffer-name) (kill-buffer (get-buffer toc-org-navigation-window-buffer-name)))
+      (when (get-buffer toc-org-navigation-pane-buffer-name) (kill-buffer (get-buffer toc-org-navigation-pane-buffer-name)))
       (kill-buffer buf)
       (delete-file tmpfile))))

--- a/toc-org-test.el
+++ b/toc-org-test.el
@@ -431,6 +431,46 @@ producing \"Selecting deleted buffer\"."
       (kill-buffer buf)
       (delete-file tmpfile))))
 
+(ert-deftest test-toc-org-nav-depth-change ()
+  "= / + / - adjust nav pane depth, clamped to [1, max-heading-depth]."
+  (when (get-buffer toc-org-navigation-pane-buffer-name)
+    (kill-buffer toc-org-navigation-pane-buffer-name))
+  (let* ((tmpfile (make-temp-file "toc-org-test" nil ".org"))
+         (buf (find-file-noselect tmpfile)))
+    (unwind-protect
+        (with-current-buffer buf
+          (insert "* H1\n** H2\n*** H3\n")
+          (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-pane)
+          (cl-letf (((symbol-function 'display-buffer) #'ignore)
+                    ((symbol-function 'select-window)  #'ignore))
+            (toc-org-navigation-pane))
+          (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-pane)
+          (let ((nav-buf (get-buffer toc-org-navigation-pane-buffer-name)))
+            (defun nav-content () (with-current-buffer nav-buf (buffer-string)))
+            ;; default depth 2: H1 and H2 visible, H3 not
+            (should     (string-match-p "H2" (nav-content)))
+            (should-not (string-match-p "H3" (nav-content)))
+            ;; increase to 3: H3 appears
+            (with-current-buffer nav-buf (toc-org--nav-increase-depth))
+            (should (string-match-p "H3" (nav-content)))
+            (should (= (buffer-local-value 'toc-org--nav-max-depth nav-buf) 3))
+            ;; increase beyond max heading depth (3): clamped at 3
+            (with-current-buffer nav-buf (toc-org--nav-increase-depth))
+            (should (= (buffer-local-value 'toc-org--nav-max-depth nav-buf) 3))
+            ;; decrease to 1: H2 and H3 gone
+            (with-current-buffer nav-buf (toc-org--nav-decrease-depth))
+            (with-current-buffer nav-buf (toc-org--nav-decrease-depth))
+            (should-not (string-match-p "H2" (nav-content)))
+            (should (= (buffer-local-value 'toc-org--nav-max-depth nav-buf) 1))
+            ;; decrease below minimum: clamped at 1
+            (with-current-buffer nav-buf (toc-org--nav-decrease-depth))
+            (should (= (buffer-local-value 'toc-org--nav-max-depth nav-buf) 1))))
+      (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-pane)
+      (when (get-buffer toc-org-navigation-pane-buffer-name)
+        (kill-buffer (get-buffer toc-org-navigation-pane-buffer-name)))
+      (kill-buffer buf)
+      (delete-file tmpfile))))
+
 (ert-deftest test-toc-org-nav-next-and-prev ()
   "M-n / M-p move the pane point and update the source window position."
   (when (get-buffer toc-org-navigation-pane-buffer-name)

--- a/toc-org.el
+++ b/toc-org.el
@@ -501,10 +501,17 @@ fallback to `markdown-follow-thing-at-point' on failure"
     (setq org-link-translation-function 'toc-org-unhrefify)
     (toc-org-insert-toc t)))
 
+(defvar toc-org-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-c t") #'toc-org-navigation-window)
+    map)
+  "Keymap for `toc-org-mode'.")
+
 ;;;###autoload
 (define-minor-mode toc-org-mode
   "Toggle `toc-org' in this buffer."
   :group toc-org
+  :keymap toc-org-mode-map
   (if toc-org-mode
       (toc-org-enable)
     (remove-hook 'before-save-hook 'toc-org-insert-toc t)

--- a/toc-org.el
+++ b/toc-org.el
@@ -578,6 +578,14 @@ fallback to `markdown-follow-thing-at-point' on failure"
               (set-window-point win (min saved-point (point-max)))
             (goto-char (point-min))))))))
 
+(defun toc-org--follow-link ()
+  "Follow the first org link on the current line."
+  (interactive)
+  (save-excursion
+    (beginning-of-line)
+    (when (re-search-forward "\\[\\[" (line-end-position) t)
+      (org-open-at-point))))
+
 ;;;###autoload
 (defun toc-org-navigation-window ()
   "Show the table of contents of the current buffer in a side window.
@@ -617,7 +625,16 @@ allowing navigation via `org-open-at-point' (\\[org-open-at-point])."
         (setq-local mode-line-format nil)
         (setq buffer-read-only t)
         (setq-local header-line-format
-                    (format " Table of Contents - %s" (buffer-name source-buf))))
+                    (format " Table of Contents - %s" (buffer-name source-buf)))
+        (let ((map (make-sparse-keymap)))
+          (set-keymap-parent map (current-local-map))
+          (define-key map "n" #'next-line)
+          (define-key map "p" #'previous-line)
+          (define-key map "f" #'forward-char)
+          (define-key map "b" #'backward-char)
+          (define-key map "k" #'kill-buffer-and-window)
+          (define-key map (kbd "RET") #'toc-org--follow-link)
+          (use-local-map map)))
 
             (with-current-buffer source-buf
               (setq toc-org--toc-buffer win-buf)

--- a/toc-org.el
+++ b/toc-org.el
@@ -139,8 +139,8 @@ size (e.g. 0.3 for 30%)."
   :type 'number
   :group 'toc-org)
 
-(defconst toc-org-navigation-window-buffer-name "*toc-org-navigation-window*"
-  "Name of the buffer used for the TOC navigation window.")
+(defconst toc-org-navigation-pane-buffer-name "*toc-org-navigation-pane*"
+  "Name of the buffer used for the TOC navigation pane.")
 
 (defvar-local toc-org--toc-buffer nil
   "TOC side window buffer associated with this buffer.")
@@ -503,7 +503,7 @@ fallback to `markdown-follow-thing-at-point' on failure"
 
 (defvar toc-org-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "C-c t") #'toc-org-navigation-window)
+    (define-key map (kbd "C-c t") #'toc-org-navigation-pane)
     map)
   "Keymap for `toc-org-mode'.")
 
@@ -542,7 +542,7 @@ fallback to `markdown-follow-thing-at-point' on failure"
                 (setq any-toc-p t)
               (kill-buffer toc-org--toc-buffer)
               (setq toc-org--toc-buffer nil)
-              (remove-hook 'after-save-hook #'toc-org--refresh-navigation-window t))))))
+              (remove-hook 'after-save-hook #'toc-org--refresh-navigation-pane t))))))
     (unless any-toc-p
       (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-window))))
 
@@ -552,10 +552,10 @@ fallback to `markdown-follow-thing-at-point' on failure"
              (buffer-live-p toc-org--toc-buffer))
     (kill-buffer toc-org--toc-buffer)
     (setq toc-org--toc-buffer nil))
-  (remove-hook 'after-save-hook #'toc-org--refresh-navigation-window t))
+  (remove-hook 'after-save-hook #'toc-org--refresh-navigation-pane t))
 
-(defun toc-org--refresh-navigation-window ()
-  "Refresh the TOC navigation window content for the current source buffer."
+(defun toc-org--refresh-navigation-pane ()
+  "Refresh the TOC navigation pane content for the current source buffer."
   (when (and toc-org--toc-buffer
              (buffer-live-p toc-org--toc-buffer))
     (let* ((source-buf   (current-buffer))
@@ -626,7 +626,7 @@ fallback to `markdown-follow-thing-at-point' on failure"
       (org-open-at-point))))
 
 ;;;###autoload
-(defun toc-org-navigation-window ()
+(defun toc-org-navigation-pane ()
   "Show the table of contents of the current buffer in a side window.
 
 Works as a toggle: calling it again closes the window.
@@ -644,14 +644,14 @@ for a fixed number of columns/lines, or a float (0.0–1.0) for a
 fraction of the frame size."
   (interactive)
   (cond
-   ((string= (buffer-name) toc-org-navigation-window-buffer-name)
+   ((string= (buffer-name) toc-org-navigation-pane-buffer-name)
     (kill-buffer-and-window))
    ((and toc-org--toc-buffer
          (buffer-live-p toc-org--toc-buffer)
          (get-buffer-window toc-org--toc-buffer))
     (kill-buffer toc-org--toc-buffer)
     (setq toc-org--toc-buffer nil)
-    (remove-hook 'after-save-hook #'toc-org--refresh-navigation-window t))
+    (remove-hook 'after-save-hook #'toc-org--refresh-navigation-pane t))
    (t
     (let* ((source-buf  (current-buffer))
            (source-file (buffer-file-name source-buf))
@@ -659,7 +659,7 @@ fraction of the frame size."
            (raw-toc     (toc-org-flush-subheadings
                          (toc-org-raw-toc markdown-p)
                          (toc-org--effective-max-depth)))
-           (win-buf     (get-buffer-create toc-org-navigation-window-buffer-name)))
+           (win-buf     (get-buffer-create toc-org-navigation-pane-buffer-name)))
       (cond
        ((not source-file)
         (kill-buffer win-buf)
@@ -687,9 +687,9 @@ fraction of the frame size."
         (with-current-buffer source-buf
           (setq toc-org--toc-buffer win-buf)
           (add-hook 'kill-buffer-hook        #'toc-org--close-toc-window-on-kill nil t)
-          (add-hook 'after-save-hook         #'toc-org--refresh-navigation-window nil t)
+          (add-hook 'after-save-hook         #'toc-org--refresh-navigation-pane nil t)
           (add-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
-          (toc-org--refresh-navigation-window)
+          (toc-org--refresh-navigation-pane)
           (toc-org--goto-current-heading))
         (select-window
          (display-buffer

--- a/toc-org.el
+++ b/toc-org.el
@@ -519,6 +519,17 @@ fallback to `markdown-follow-thing-at-point' on failure"
     (when (equal org-link-translation-function 'toc-org-unhrefify)
       (setq org-link-translation-function nil))))
 
+(defun toc-org--effective-max-depth ()
+  "Return the max depth for the TOC: from the :TOC_N: tag if present, else `toc-org-max-depth'."
+  (save-excursion
+    (goto-char (point-min))
+    (let* ((case-fold-search t)
+           (heading-re (if (derived-mode-p 'markdown-mode) "^#" "^\\*")))
+      (if (re-search-forward (concat heading-re toc-org-toc-org-regexp) nil t)
+          (let ((tag (match-string 2)))
+            (if tag (- (aref tag 1) ?0) toc-org-max-depth))
+        toc-org-max-depth))))
+
 (defun toc-org--close-toc-window ()
   "Close TOC side windows whose source buffers are no longer visible."
   (let ((any-toc-p nil))
@@ -552,7 +563,7 @@ fallback to `markdown-follow-thing-at-point' on failure"
            (markdown-p   (derived-mode-p 'markdown-mode))
            (raw-toc      (toc-org-flush-subheadings
                           (toc-org-raw-toc markdown-p)
-                          toc-org-max-depth))
+                          (toc-org--effective-max-depth)))
            (toc-buf      toc-org--toc-buffer)
            (win          (get-buffer-window toc-buf))
            (saved-point  (when win (window-point win))))
@@ -584,6 +595,27 @@ fallback to `markdown-follow-thing-at-point' on failure"
           (if (and win saved-point)
               (set-window-point win (min saved-point (point-max)))
             (goto-char (point-min))))))))
+
+(defun toc-org--goto-current-heading ()
+  "In the TOC buffer, position point at the entry for the heading at point."
+  (when (and toc-org--toc-buffer
+             (buffer-live-p toc-org--toc-buffer))
+    (let* ((toc-buf    toc-org--toc-buffer)
+           (markdown-p (derived-mode-p 'markdown-mode))
+           (heading-re (if markdown-p "^\\(#+\\)[ \t]+" "^\\(\\*+\\)[ \t]+"))
+           (max-depth  (toc-org--effective-max-depth))
+           (line-num
+            (save-excursion
+              (end-of-line)
+              (catch 'found
+                (while (re-search-backward heading-re nil t)
+                  (when (<= (length (match-string 1)) max-depth)
+                    (throw 'found (line-number-at-pos))))))))
+      (when line-num
+        (with-current-buffer toc-buf
+          (goto-char (point-min))
+          (when (re-search-forward (format "::%d\\]\\[" line-num) nil t)
+            (beginning-of-line)))))))
 
 (defun toc-org--follow-link ()
   "Follow the first org link on the current line."
@@ -626,7 +658,7 @@ fraction of the frame size."
            (markdown-p  (derived-mode-p 'markdown-mode))
            (raw-toc     (toc-org-flush-subheadings
                          (toc-org-raw-toc markdown-p)
-                         toc-org-max-depth))
+                         (toc-org--effective-max-depth)))
            (win-buf     (get-buffer-create toc-org-navigation-window-buffer-name)))
       (cond
        ((not source-file)
@@ -657,7 +689,8 @@ fraction of the frame size."
           (add-hook 'kill-buffer-hook        #'toc-org--close-toc-window-on-kill nil t)
           (add-hook 'after-save-hook         #'toc-org--refresh-navigation-window nil t)
           (add-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
-          (toc-org--refresh-navigation-window))
+          (toc-org--refresh-navigation-window)
+          (toc-org--goto-current-heading))
         (select-window
          (display-buffer
           win-buf

--- a/toc-org.el
+++ b/toc-org.el
@@ -527,7 +527,7 @@ fallback to `markdown-follow-thing-at-point' on failure"
     (setq toc-org--toc-buffer nil)))
 
 ;;;###autoload
-(defun toc-org-show-toc-window ()
+(defun toc-org-navigation-window ()
   "Show the table of contents of the current buffer in a side window.
 The TOC is displayed in a dedicated buffer with `org-mode' enabled,
 allowing navigation via `org-open-at-point' (\\[org-open-at-point])."

--- a/toc-org.el
+++ b/toc-org.el
@@ -121,6 +121,24 @@ the TOC links (even if the style is different from org)."
 opening. The keys are hrefified headings, the values are original
 headings.")
 
+(defcustom toc-org-side-window-side 'left
+  "Side of the frame where the TOC side window is displayed.
+Possible values are `left', `right', `top', and `bottom'."
+  :type '(choice (const left)
+                 (const right)
+                 (const top)
+                 (const bottom))
+  :group 'toc-org)
+
+(defcustom toc-org-side-window-size 35
+  "Size of the TOC side window.
+This controls the width for `left'/`right' sides, and the height
+for `top'/`bottom' sides.  An integer means the number of columns
+or lines; a float between 0 and 1 means a fraction of the frame
+size (e.g. 0.3 for 30%)."
+  :type 'number
+  :group 'toc-org)
+
 (defun toc-org-raw-toc (markdown-syntax-p)
   "Return the \"raw\" table of contents of the current file,
 i.e. simply flush everything that's not a heading and strip
@@ -521,11 +539,12 @@ allowing navigation via `org-open-at-point' (\\[org-open-at-point])."
           (setq-local header-line-format
                       (format " TOC - %s" (buffer-name source-buf)))))
       (display-buffer
-       win-buf
-       '(display-buffer-in-side-window
-         (side         . left)
-         (window-width . 35)
-         (slot         . 0))))))
+        win-buf
+        (cons 'display-buffer-in-side-window
+              (list (cons 'side          toc-org-side-window-side)
+                    (cons 'window-width  toc-org-side-window-size)
+                    (cons 'window-height toc-org-side-window-size)
+                    '(slot . 0)))))))
 
 ;; Local Variables:
 ;; compile-command: "emacs -batch -l ert -l toc-org.el -l toc-org-test.el -f ert-run-tests-batch-and-exit && emacs -batch -f batch-byte-compile toc-org.el 2>&1 | sed -n '/Warning\|Error/p' | xargs -r ls"

--- a/toc-org.el
+++ b/toc-org.el
@@ -651,15 +651,15 @@ Uses the depth from the :TOC_N: tag if present, else `toc-org-max-depth'."
               (forward-line (1- line-num)))))))))
 
 (defun toc-org--nav-next ()
-  "Move to the next entry in the navigation pane and show it in the source buffer."
+  "Move to next nav pane entry and show it in the source buffer."
   (interactive)
-  (next-line)
+  (forward-line 1)
   (toc-org--nav-show-heading))
 
 (defun toc-org--nav-prev ()
-  "Move to the previous entry in the navigation pane and show it in the source buffer."
+  "Move to previous nav pane entry and show it in the source buffer."
   (interactive)
-  (previous-line)
+  (forward-line -1)
   (toc-org--nav-show-heading))
 
 ;;;###autoload

--- a/toc-org.el
+++ b/toc-org.el
@@ -611,64 +611,61 @@ appears on (left, right, top, or bottom).  Customize
 for a fixed number of columns/lines, or a float (0.0–1.0) for a
 fraction of the frame size."
   (interactive)
-
-   (if (string= (buffer-name) toc-org-navigation-window-buffer-name)
-     (kill-buffer-and-window)
-
-     (if (and toc-org--toc-buffer
-              (buffer-live-p toc-org--toc-buffer)
-              (get-buffer-window toc-org--toc-buffer))
-       (progn
-         (kill-buffer toc-org--toc-buffer)
-         (setq toc-org--toc-buffer nil)
-         (remove-hook 'after-save-hook #'toc-org--refresh-navigation-window t))
-
-  (let* ((source-buf  (current-buffer))
-         (source-file (buffer-file-name source-buf))
-         (markdown-p  (derived-mode-p 'markdown-mode))
-         (raw-toc     (toc-org-flush-subheadings
-                       (toc-org-raw-toc markdown-p)
-                       toc-org-max-depth))
-         (win-buf     (get-buffer-create toc-org-navigation-window-buffer-name)))
-    (if (not source-file)
-        (progn
-          (kill-buffer win-buf)
-          (message "toc-org: Buffer is not visiting a file."))
-    (if (string-empty-p (string-trim raw-toc))
-        (progn
-          (kill-buffer win-buf)
-          (message "toc-org: No headings found in this buffer."))
-      (with-current-buffer win-buf
-        (org-mode)
-        (display-line-numbers-mode -1)
-        (setq-local mode-line-format nil)
-        (setq buffer-read-only t)
-        (setq-local header-line-format
-                    (format " Table of Contents - %s" (buffer-name source-buf)))
-        (let ((map (make-sparse-keymap)))
-          (set-keymap-parent map (current-local-map))
-          (define-key map "n" #'next-line)
-          (define-key map "p" #'previous-line)
-          (define-key map "f" #'forward-char)
-          (define-key map "b" #'backward-char)
-          (define-key map "k" #'kill-buffer-and-window)
-          (define-key map (kbd "RET") #'toc-org--follow-link)
-          (use-local-map map)))
-
-            (with-current-buffer source-buf
-              (setq toc-org--toc-buffer win-buf)
-              (add-hook 'kill-buffer-hook        #'toc-org--close-toc-window-on-kill nil t)
-              (add-hook 'after-save-hook         #'toc-org--refresh-navigation-window nil t)
-              (add-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
-              (toc-org--refresh-navigation-window))
-            (select-window
-              (display-buffer
-                win-buf
-                (cons 'display-buffer-in-side-window
-                      (list (cons 'side          toc-org-side-window-side)
-                            (cons 'window-width  toc-org-side-window-size)
-                            (cons 'window-height toc-org-side-window-size)
-                            '(slot . 0)))))))))))
+  (cond
+   ((string= (buffer-name) toc-org-navigation-window-buffer-name)
+    (kill-buffer-and-window))
+   ((and toc-org--toc-buffer
+         (buffer-live-p toc-org--toc-buffer)
+         (get-buffer-window toc-org--toc-buffer))
+    (kill-buffer toc-org--toc-buffer)
+    (setq toc-org--toc-buffer nil)
+    (remove-hook 'after-save-hook #'toc-org--refresh-navigation-window t))
+   (t
+    (let* ((source-buf  (current-buffer))
+           (source-file (buffer-file-name source-buf))
+           (markdown-p  (derived-mode-p 'markdown-mode))
+           (raw-toc     (toc-org-flush-subheadings
+                         (toc-org-raw-toc markdown-p)
+                         toc-org-max-depth))
+           (win-buf     (get-buffer-create toc-org-navigation-window-buffer-name)))
+      (cond
+       ((not source-file)
+        (kill-buffer win-buf)
+        (message "toc-org: Buffer is not visiting a file."))
+       ((string-empty-p (string-trim raw-toc))
+        (kill-buffer win-buf)
+        (message "toc-org: No headings found in this buffer."))
+       (t
+        (with-current-buffer win-buf
+          (org-mode)
+          (display-line-numbers-mode -1)
+          (setq-local mode-line-format nil)
+          (setq buffer-read-only t)
+          (setq-local header-line-format
+                      (format " Table of Contents - %s" (buffer-name source-buf)))
+          (let ((map (make-sparse-keymap)))
+            (set-keymap-parent map (current-local-map))
+            (define-key map "n" #'next-line)
+            (define-key map "p" #'previous-line)
+            (define-key map "f" #'forward-char)
+            (define-key map "b" #'backward-char)
+            (define-key map "k" #'kill-buffer-and-window)
+            (define-key map (kbd "RET") #'toc-org--follow-link)
+            (use-local-map map)))
+        (with-current-buffer source-buf
+          (setq toc-org--toc-buffer win-buf)
+          (add-hook 'kill-buffer-hook        #'toc-org--close-toc-window-on-kill nil t)
+          (add-hook 'after-save-hook         #'toc-org--refresh-navigation-window nil t)
+          (add-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
+          (toc-org--refresh-navigation-window))
+        (select-window
+         (display-buffer
+          win-buf
+          (cons 'display-buffer-in-side-window
+                (list (cons 'side          toc-org-side-window-side)
+                      (cons 'window-width  toc-org-side-window-size)
+                      (cons 'window-height toc-org-side-window-size)
+                      '(slot . 0)))))))))))
 
 ;; Local Variables:
 ;; compile-command: "emacs -batch -l ert -l toc-org.el -l toc-org-test.el -f ert-run-tests-batch-and-exit && emacs -batch -f batch-byte-compile toc-org.el 2>&1 | sed -n '/Warning\|Error/p' | xargs -r ls"

--- a/toc-org.el
+++ b/toc-org.el
@@ -145,6 +145,9 @@ size (e.g. 0.3 for 30%)."
 (defvar-local toc-org--toc-buffer nil
   "TOC navigation pane buffer associated with this buffer.")
 
+(defvar-local toc-org--nav-source-buffer nil
+  "Source buffer associated with this navigation pane buffer.")
+
 (defun toc-org-raw-toc (markdown-syntax-p)
   "Return the \"raw\" table of contents of the current file,
 i.e. simply flush everything that's not a heading and strip
@@ -161,6 +164,13 @@ auxiliary text."
       (when markdown-syntax-p
         (save-excursion
           (let ((case-fold-search t))
+            ;; remove ``` code fence blocks so their # lines aren't treated as headings
+            (goto-char (point-min))
+            (while (re-search-forward "^```" nil t)
+              (let ((beg (line-beginning-position)))
+                (when (re-search-forward "^```" nil t)
+                  (forward-line 1)
+                  (delete-region beg (point)))))
             (goto-char (point-min))
             (while (re-search-forward "^#+ " nil t)
               (replace-match (concat
@@ -626,6 +636,32 @@ Uses the depth from the :TOC_N: tag if present, else `toc-org-max-depth'."
     (when (re-search-forward "\\[\\[" (line-end-position) t)
       (org-open-at-point))))
 
+(defun toc-org--nav-show-heading ()
+  "Move point in the source buffer to the heading on the current nav-pane line."
+  (when (and toc-org--nav-source-buffer
+             (buffer-live-p toc-org--nav-source-buffer))
+    (save-excursion
+      (beginning-of-line)
+      (when (re-search-forward "::\\([0-9]+\\)\\]\\[" (line-end-position) t)
+        (let ((line-num (string-to-number (match-string 1)))
+              (source-win (get-buffer-window toc-org--nav-source-buffer)))
+          (when source-win
+            (with-selected-window source-win
+              (goto-char (point-min))
+              (forward-line (1- line-num)))))))))
+
+(defun toc-org--nav-next ()
+  "Move to the next entry in the navigation pane and show it in the source buffer."
+  (interactive)
+  (next-line)
+  (toc-org--nav-show-heading))
+
+(defun toc-org--nav-prev ()
+  "Move to the previous entry in the navigation pane and show it in the source buffer."
+  (interactive)
+  (previous-line)
+  (toc-org--nav-show-heading))
+
 ;;;###autoload
 (defun toc-org-navigation-pane ()
   "Show the table of contents of the current buffer as a side pane.
@@ -633,10 +669,12 @@ Uses the depth from the :TOC_N: tag if present, else `toc-org-max-depth'."
 Works as a toggle: calling it again closes the pane.
 
 The TOC buffer is read-only with these single-letter shortcuts:
-  n / p   next / previous line
-  f / b   forward / backward character
-  k       close the pane
-  RET     follow the link on the current line
+  n / p           next / previous line
+  f / b           forward / backward character
+  k               close the pane
+  RET             follow the link on the current line
+  M-n / M-<down>  move to next entry and show it in the source buffer
+  M-p / M-<up>    move to previous entry and show it in the source buffer
 
 Customize `toc-org-side-window-side' to set which side the pane
 appears on (left, right, top, or bottom).  Customize
@@ -668,6 +706,7 @@ fraction of the frame size."
           (display-line-numbers-mode -1)
           (setq-local mode-line-format nil)
           (setq-local buffer-read-only t)
+          (setq-local toc-org--nav-source-buffer source-buf)
           (setq-local header-line-format
                       (format " Table of Contents - %s" (buffer-name source-buf)))
           (let ((map (make-sparse-keymap)))
@@ -678,6 +717,10 @@ fraction of the frame size."
             (define-key map "b" #'backward-char)
             (define-key map "k" #'kill-buffer-and-window)
             (define-key map (kbd "RET") #'toc-org--follow-link)
+            (define-key map (kbd "M-n") #'toc-org--nav-next)
+            (define-key map (kbd "M-p") #'toc-org--nav-prev)
+            (define-key map (kbd "M-<down>") #'toc-org--nav-next)
+            (define-key map (kbd "M-<up>") #'toc-org--nav-prev)
             (use-local-map map)))
         (with-current-buffer source-buf
           (setq toc-org--toc-buffer win-buf)

--- a/toc-org.el
+++ b/toc-org.el
@@ -532,6 +532,17 @@ fallback to `markdown-follow-thing-at-point' on failure"
 The TOC is displayed in a dedicated buffer with `org-mode' enabled,
 allowing navigation via `org-open-at-point' (\\[org-open-at-point])."
   (interactive)
+
+   (if (string= (buffer-name) "*org-toc*")
+     (kill-buffer-and-window)
+
+     (if (and toc-org--toc-buffer
+              (buffer-live-p toc-org--toc-buffer)
+              (get-buffer-window toc-org--toc-buffer))
+       (progn
+         (kill-buffer toc-org--toc-buffer)
+         (setq toc-org--toc-buffer nil))
+
   (let* ((source-buf  (current-buffer))
          (source-file (buffer-file-name source-buf))
          (markdown-p  (derived-mode-p 'markdown-mode))
@@ -567,6 +578,8 @@ allowing navigation via `org-open-at-point' (\\[org-open-at-point])."
                                     source-file line-num title)
                             "\n")))))
           (org-mode)
+          (display-line-numbers-mode -1)
+          (setq-local mode-line-format nil)
           (setq buffer-read-only t)
           (goto-char (point-min))
           (setq-local header-line-format
@@ -577,13 +590,14 @@ allowing navigation via `org-open-at-point' (\\[org-open-at-point])."
                                  (setq toc-org--toc-buffer win-buf)
                                  (add-hook 'kill-buffer-hook        #'toc-org--close-toc-window-on-kill nil t)
                                  (add-hook 'buffer-list-update-hook #'toc-org--close-toc-window))
-      (display-buffer
-        win-buf
-        (cons 'display-buffer-in-side-window
-              (list (cons 'side          toc-org-side-window-side)
-                    (cons 'window-width  toc-org-side-window-size)
-                    (cons 'window-height toc-org-side-window-size)
-                    '(slot . 0)))))))
+            (select-window
+              (display-buffer
+                win-buf
+                (cons 'display-buffer-in-side-window
+                      (list (cons 'side          toc-org-side-window-side)
+                            (cons 'window-width  toc-org-side-window-size)
+                            (cons 'window-height toc-org-side-window-size)
+                            '(slot . 0))))))))))
 
 ;; Local Variables:
 ;; compile-command: "emacs -batch -l ert -l toc-org.el -l toc-org-test.el -f ert-run-tests-batch-and-exit && emacs -batch -f batch-byte-compile toc-org.el 2>&1 | sed -n '/Warning\|Error/p' | xargs -r ls"

--- a/toc-org.el
+++ b/toc-org.el
@@ -524,15 +524,28 @@ allowing navigation via `org-open-at-point' (\\[org-open-at-point])."
       (with-current-buffer win-buf
         (let ((inhibit-read-only t))
           (erase-buffer)
-          (dolist (line (split-string raw-toc "\n" t))
-            (when (string-match "^\\(\\*+\\)[ \t]+\\(.*\\)" line)
-              (let* ((depth  (1- (length (match-string 1 line))))
-                     (title  (match-string 2 line))
-                     (indent (make-string (* 2 depth) ?\s)))
-                (insert indent "- "
-                        (format "[[file:%s::*%s][%s]]"
-                                source-file title title)
-                        "\n"))))
+            (dolist (line (split-string raw-toc "\n" t))
+              (when (string-match "^\\(\\*+\\)[ \t]+\\(.*\\)" line)
+                (let* ((depth  (1- (length (match-string 1 line))))
+                       (title  (replace-regexp-in-string
+                                 toc-org-statistics-cookies-regexp ""
+                                 (match-string 2 line)))
+                       (indent (make-string (* 2 depth) ?\s))
+		(line-num (with-current-buffer source-buf
+            (save-excursion
+              (goto-char (point-min))
+              (when (re-search-forward
+                     (concat (if markdown-p
+                                 "^#+[ \t]+"
+                               "^\\*+[ \t]+\\(?:[A-Z]+[ \t]+\\)?\\(?:\\[#.\\][ \t]+\\)?")
+                             (regexp-quote title))
+                     nil t)
+                (line-number-at-pos))))))
+                  (when line-num
+                    (insert indent "- "
+                            (format "[[file:%s::%d][%s]]"
+                                    source-file line-num title)
+                            "\n")))))
           (org-mode)
           (setq buffer-read-only t)
           (goto-char (point-min))

--- a/toc-org.el
+++ b/toc-org.el
@@ -585,7 +585,6 @@ allowing navigation via `org-open-at-point' (\\[org-open-at-point])."
           (setq-local header-line-format
                       (format " TOC - %s" (buffer-name source-buf)))))
 
-            (local-set-key (kbd "q") #'kill-buffer-and-window)
             (with-current-buffer source-buf
                                  (setq toc-org--toc-buffer win-buf)
                                  (add-hook 'kill-buffer-hook        #'toc-org--close-toc-window-on-kill nil t)

--- a/toc-org.el
+++ b/toc-org.el
@@ -148,6 +148,9 @@ size (e.g. 0.3 for 30%)."
 (defvar-local toc-org--nav-source-buffer nil
   "Source buffer associated with this navigation pane buffer.")
 
+(defvar-local toc-org--nav-max-depth nil
+  "Max depth shown in this navigation pane, or nil to use the default.")
+
 (defun toc-org-raw-toc (markdown-syntax-p)
   "Return the \"raw\" table of contents of the current file,
 i.e. simply flush everything that's not a heading and strip
@@ -662,6 +665,39 @@ Uses the depth from the :TOC_N: tag if present, else `toc-org-max-depth'."
   (forward-line -1)
   (toc-org--nav-show-heading))
 
+(defun toc-org--max-heading-depth ()
+  "Return the maximum heading depth present in the current buffer's TOC."
+  (let ((raw (toc-org-raw-toc (derived-mode-p 'markdown-mode)))
+        (depth 0))
+    (dolist (line (split-string raw "\n" t))
+      (when (string-match "^\\(\\*+\\)" line)
+        (setq depth (max depth (length (match-string 1 line))))))
+    depth))
+
+(defun toc-org--nav-change-depth (delta)
+  "Change the navigation pane max depth by DELTA and refresh."
+  (when (and toc-org--nav-source-buffer
+             (buffer-live-p toc-org--nav-source-buffer))
+    (let* ((current (or toc-org--nav-max-depth
+                        (with-current-buffer toc-org--nav-source-buffer
+                          (toc-org--effective-max-depth))))
+           (max-possible (with-current-buffer toc-org--nav-source-buffer
+                           (toc-org--max-heading-depth)))
+           (new-depth (max 1 (min (+ current delta) max-possible))))
+      (setq toc-org--nav-max-depth new-depth)
+      (with-current-buffer toc-org--nav-source-buffer
+        (toc-org--refresh-navigation-pane new-depth)))))
+
+(defun toc-org--nav-increase-depth ()
+  "Increase the max depth shown in the navigation pane."
+  (interactive)
+  (toc-org--nav-change-depth 1))
+
+(defun toc-org--nav-decrease-depth ()
+  "Decrease the max depth shown in the navigation pane."
+  (interactive)
+  (toc-org--nav-change-depth -1))
+
 ;;;###autoload
 (defun toc-org-navigation-pane ()
   "Show the table of contents of the current buffer as a side pane.
@@ -675,6 +711,8 @@ The TOC buffer is read-only with these single-letter shortcuts:
   RET             follow the link on the current line
   M-n / M-<down>  move to next entry and show it in the source buffer
   M-p / M-<up>    move to previous entry and show it in the source buffer
+  = / +           increase max depth
+  -               decrease max depth
 
 Customize `toc-org-side-window-side' to set which side the pane
 appears on (left, right, top, or bottom).  Customize
@@ -721,6 +759,9 @@ fraction of the frame size."
             (define-key map (kbd "M-p") #'toc-org--nav-prev)
             (define-key map (kbd "M-<down>") #'toc-org--nav-next)
             (define-key map (kbd "M-<up>") #'toc-org--nav-prev)
+            (define-key map "=" #'toc-org--nav-increase-depth)
+            (define-key map "+" #'toc-org--nav-increase-depth)
+            (define-key map "-" #'toc-org--nav-decrease-depth)
             (use-local-map map)))
         (with-current-buffer source-buf
           (setq toc-org--toc-buffer win-buf)

--- a/toc-org.el
+++ b/toc-org.el
@@ -139,6 +139,9 @@ size (e.g. 0.3 for 30%)."
   :type 'number
   :group 'toc-org)
 
+(defvar-local toc-org--toc-buffer nil
+  "TOC side window buffer associated with this buffer.")
+
 (defun toc-org-raw-toc (markdown-syntax-p)
   "Return the \"raw\" table of contents of the current file,
 i.e. simply flush everything that's not a heading and strip
@@ -506,6 +509,23 @@ fallback to `markdown-follow-thing-at-point' on failure"
     (when (equal org-link-translation-function 'toc-org-unhrefify)
       (setq org-link-translation-function nil))))
 
+(defun toc-org--close-toc-window ()
+  "Close TOC side windows whose source buffers are no longer visible."
+  (dolist (buf (buffer-list))
+    (with-current-buffer buf
+      (when (and toc-org--toc-buffer
+                 (buffer-live-p toc-org--toc-buffer)
+                 (not (get-buffer-window buf)))
+        (kill-buffer toc-org--toc-buffer)
+        (setq toc-org--toc-buffer nil)))))
+
+(defun toc-org--close-toc-window-on-kill ()
+  "Close the TOC side window when the source buffer is killed."
+  (when (and toc-org--toc-buffer
+             (buffer-live-p toc-org--toc-buffer))
+    (kill-buffer toc-org--toc-buffer)
+    (setq toc-org--toc-buffer nil)))
+
 ;;;###autoload
 (defun toc-org-show-toc-window ()
   "Show the table of contents of the current buffer in a side window.
@@ -551,6 +571,12 @@ allowing navigation via `org-open-at-point' (\\[org-open-at-point])."
           (goto-char (point-min))
           (setq-local header-line-format
                       (format " TOC - %s" (buffer-name source-buf)))))
+
+            (local-set-key (kbd "q") #'kill-buffer-and-window)
+            (with-current-buffer source-buf
+                                 (setq toc-org--toc-buffer win-buf)
+                                 (add-hook 'kill-buffer-hook        #'toc-org--close-toc-window-on-kill nil t)
+                                 (add-hook 'buffer-list-update-hook #'toc-org--close-toc-window))
       (display-buffer
         win-buf
         (cons 'display-buffer-in-side-window

--- a/toc-org.el
+++ b/toc-org.el
@@ -651,7 +651,8 @@ Uses the depth from the :TOC_N: tag if present, else `toc-org-max-depth'."
           (when source-win
             (with-selected-window source-win
               (goto-char (point-min))
-              (forward-line (1- line-num)))))))))
+              (forward-line (1- line-num))
+              (recenter))))))))
 
 (defun toc-org--nav-next ()
   "Move to next nav pane entry and show it in the source buffer."

--- a/toc-org.el
+++ b/toc-org.el
@@ -570,12 +570,12 @@ Uses the depth from the :TOC_N: tag if present, else `toc-org-max-depth'."
   (when (and toc-org--toc-buffer
              (buffer-live-p toc-org--toc-buffer))
     (let* ((source-buf   (current-buffer))
+           (toc-buf      toc-org--toc-buffer)
            (source-file  (buffer-file-name source-buf))
            (markdown-p   (derived-mode-p 'markdown-mode))
            (raw-toc      (toc-org-flush-subheadings
                           (toc-org-raw-toc markdown-p)
                           (or max-depth (toc-org--effective-max-depth))))
-           (toc-buf      toc-org--toc-buffer)
            (win          (get-buffer-window toc-buf))
            (saved-point  (when win (window-point win))))
       (with-current-buffer toc-buf
@@ -724,10 +724,12 @@ fraction of the frame size."
             (use-local-map map)))
         (with-current-buffer source-buf
           (setq toc-org--toc-buffer win-buf)
-          (add-hook 'kill-buffer-hook        #'toc-org--close-toc-pane-on-kill nil t)
-          (add-hook 'after-save-hook         #'toc-org--refresh-navigation-pane nil t)
-          (add-hook 'buffer-list-update-hook #'toc-org--close-toc-pane)
-          (toc-org--refresh-navigation-pane max-depth))
+          (add-hook 'kill-buffer-hook  #'toc-org--close-toc-pane-on-kill nil t)
+          (add-hook 'after-save-hook   #'toc-org--refresh-navigation-pane nil t)
+          (toc-org--refresh-navigation-pane max-depth)
+          ;; add after refresh so with-temp-buffer inside toc-org-raw-toc
+          ;; doesn't fire the hook before the pane window is shown
+          (add-hook 'buffer-list-update-hook #'toc-org--close-toc-pane))
         (if (with-current-buffer win-buf (zerop (buffer-size)))
             (progn
               (kill-buffer win-buf)

--- a/toc-org.el
+++ b/toc-org.el
@@ -139,6 +139,9 @@ size (e.g. 0.3 for 30%)."
   :type 'number
   :group 'toc-org)
 
+(defconst toc-org-navigation-window-buffer-name "*toc-org-navigation-window*"
+  "Name of the buffer used for the TOC navigation window.")
+
 (defvar-local toc-org--toc-buffer nil
   "TOC side window buffer associated with this buffer.")
 
@@ -193,9 +196,9 @@ auxiliary text."
 
       ;; don't include the TOC itself
       (goto-char (point-min))
-      (re-search-forward (concat "^\\*" toc-org-toc-org-regexp) nil t)
-      (beginning-of-line)
-      (delete-region (point) (progn (forward-line 1) (point)))
+      (when (re-search-forward (concat "^\\*" toc-org-toc-org-regexp) nil t)
+        (beginning-of-line)
+        (delete-region (point) (progn (forward-line 1) (point))))
 
       ;; strip states
       (unless leave-states-p
@@ -511,20 +514,69 @@ fallback to `markdown-follow-thing-at-point' on failure"
 
 (defun toc-org--close-toc-window ()
   "Close TOC side windows whose source buffers are no longer visible."
-  (dolist (buf (buffer-list))
-    (with-current-buffer buf
-      (when (and toc-org--toc-buffer
-                 (buffer-live-p toc-org--toc-buffer)
-                 (not (get-buffer-window buf)))
-        (kill-buffer toc-org--toc-buffer)
-        (setq toc-org--toc-buffer nil)))))
+  (let ((any-toc-p nil))
+    (dolist (buf (buffer-list))
+      (when (buffer-live-p buf)
+        (with-current-buffer buf
+          (when (and toc-org--toc-buffer
+                     (buffer-live-p toc-org--toc-buffer))
+            (if (get-buffer-window buf)
+                (setq any-toc-p t)
+              (kill-buffer toc-org--toc-buffer)
+              (setq toc-org--toc-buffer nil)
+              (remove-hook 'after-save-hook #'toc-org--refresh-navigation-window t))))))
+    (unless any-toc-p
+      (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-window))))
 
 (defun toc-org--close-toc-window-on-kill ()
   "Close the TOC side window when the source buffer is killed."
   (when (and toc-org--toc-buffer
              (buffer-live-p toc-org--toc-buffer))
     (kill-buffer toc-org--toc-buffer)
-    (setq toc-org--toc-buffer nil)))
+    (setq toc-org--toc-buffer nil))
+  (remove-hook 'after-save-hook #'toc-org--refresh-navigation-window t))
+
+(defun toc-org--refresh-navigation-window ()
+  "Refresh the TOC navigation window content for the current source buffer."
+  (when (and toc-org--toc-buffer
+             (buffer-live-p toc-org--toc-buffer))
+    (let* ((source-buf   (current-buffer))
+           (source-file  (buffer-file-name source-buf))
+           (markdown-p   (derived-mode-p 'markdown-mode))
+           (raw-toc      (toc-org-flush-subheadings
+                          (toc-org-raw-toc markdown-p)
+                          toc-org-max-depth))
+           (toc-buf      toc-org--toc-buffer)
+           (win          (get-buffer-window toc-buf))
+           (saved-point  (when win (window-point win))))
+      (with-current-buffer toc-buf
+        (let ((inhibit-read-only t))
+          (erase-buffer)
+          (dolist (line (split-string raw-toc "\n" t))
+            (when (string-match "^\\(\\*+\\)[ \t]+\\(.*\\)" line)
+              (let* ((depth    (1- (length (match-string 1 line))))
+                     (title    (replace-regexp-in-string
+                                 toc-org-statistics-cookies-regexp ""
+                                 (match-string 2 line)))
+                     (indent   (make-string (* 2 depth) ?\s))
+                     (line-num (with-current-buffer source-buf
+                                 (save-excursion
+                                   (goto-char (point-min))
+                                   (when (re-search-forward
+                                          (concat (if markdown-p
+                                                      "^#+[ \t]+"
+                                                    "^\\*+[ \t]+\\(?:[A-Z]+[ \t]+\\)?\\(?:\\[#.\\][ \t]+\\)?")
+                                                  (regexp-quote title))
+                                          nil t)
+                                     (line-number-at-pos))))))
+                (when line-num
+                  (insert indent "- "
+                          (format "[[file:%s::%d][%s]]"
+                                  source-file line-num title)
+                          "\n")))))
+          (if (and win saved-point)
+              (set-window-point win (min saved-point (point-max)))
+            (goto-char (point-min))))))))
 
 ;;;###autoload
 (defun toc-org-navigation-window ()
@@ -533,7 +585,7 @@ The TOC is displayed in a dedicated buffer with `org-mode' enabled,
 allowing navigation via `org-open-at-point' (\\[org-open-at-point])."
   (interactive)
 
-   (if (string= (buffer-name) "*org-toc*")
+   (if (string= (buffer-name) toc-org-navigation-window-buffer-name)
      (kill-buffer-and-window)
 
      (if (and toc-org--toc-buffer
@@ -541,7 +593,8 @@ allowing navigation via `org-open-at-point' (\\[org-open-at-point])."
               (get-buffer-window toc-org--toc-buffer))
        (progn
          (kill-buffer toc-org--toc-buffer)
-         (setq toc-org--toc-buffer nil))
+         (setq toc-org--toc-buffer nil)
+         (remove-hook 'after-save-hook #'toc-org--refresh-navigation-window t))
 
   (let* ((source-buf  (current-buffer))
          (source-file (buffer-file-name source-buf))
@@ -549,46 +602,29 @@ allowing navigation via `org-open-at-point' (\\[org-open-at-point])."
          (raw-toc     (toc-org-flush-subheadings
                        (toc-org-raw-toc markdown-p)
                        toc-org-max-depth))
-         (win-buf     (get-buffer-create "*org-toc*")))
+         (win-buf     (get-buffer-create toc-org-navigation-window-buffer-name)))
+    (if (not source-file)
+        (progn
+          (kill-buffer win-buf)
+          (message "toc-org: Buffer is not visiting a file."))
     (if (string-empty-p (string-trim raw-toc))
-        (message "toc-org: No :toc: heading found in this buffer.")
+        (progn
+          (kill-buffer win-buf)
+          (message "toc-org: No headings found in this buffer."))
       (with-current-buffer win-buf
-        (let ((inhibit-read-only t))
-          (erase-buffer)
-            (dolist (line (split-string raw-toc "\n" t))
-              (when (string-match "^\\(\\*+\\)[ \t]+\\(.*\\)" line)
-                (let* ((depth  (1- (length (match-string 1 line))))
-                       (title  (replace-regexp-in-string
-                                 toc-org-statistics-cookies-regexp ""
-                                 (match-string 2 line)))
-                       (indent (make-string (* 2 depth) ?\s))
-		(line-num (with-current-buffer source-buf
-            (save-excursion
-              (goto-char (point-min))
-              (when (re-search-forward
-                     (concat (if markdown-p
-                                 "^#+[ \t]+"
-                               "^\\*+[ \t]+\\(?:[A-Z]+[ \t]+\\)?\\(?:\\[#.\\][ \t]+\\)?")
-                             (regexp-quote title))
-                     nil t)
-                (line-number-at-pos))))))
-                  (when line-num
-                    (insert indent "- "
-                            (format "[[file:%s::%d][%s]]"
-                                    source-file line-num title)
-                            "\n")))))
-          (org-mode)
-          (display-line-numbers-mode -1)
-          (setq-local mode-line-format nil)
-          (setq buffer-read-only t)
-          (goto-char (point-min))
-          (setq-local header-line-format
-                      (format " TOC - %s" (buffer-name source-buf)))))
+        (org-mode)
+        (display-line-numbers-mode -1)
+        (setq-local mode-line-format nil)
+        (setq buffer-read-only t)
+        (setq-local header-line-format
+                    (format " Table of Contents - %s" (buffer-name source-buf))))
 
             (with-current-buffer source-buf
-                                 (setq toc-org--toc-buffer win-buf)
-                                 (add-hook 'kill-buffer-hook        #'toc-org--close-toc-window-on-kill nil t)
-                                 (add-hook 'buffer-list-update-hook #'toc-org--close-toc-window))
+              (setq toc-org--toc-buffer win-buf)
+              (add-hook 'kill-buffer-hook        #'toc-org--close-toc-window-on-kill nil t)
+              (add-hook 'after-save-hook         #'toc-org--refresh-navigation-window nil t)
+              (add-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
+              (toc-org--refresh-navigation-window))
             (select-window
               (display-buffer
                 win-buf
@@ -596,7 +632,7 @@ allowing navigation via `org-open-at-point' (\\[org-open-at-point])."
                       (list (cons 'side          toc-org-side-window-side)
                             (cons 'window-width  toc-org-side-window-size)
                             (cons 'window-height toc-org-side-window-size)
-                            '(slot . 0))))))))))
+                            '(slot . 0)))))))))))
 
 ;; Local Variables:
 ;; compile-command: "emacs -batch -l ert -l toc-org.el -l toc-org-test.el -f ert-run-tests-batch-and-exit && emacs -batch -f batch-byte-compile toc-org.el 2>&1 | sed -n '/Warning\|Error/p' | xargs -r ls"

--- a/toc-org.el
+++ b/toc-org.el
@@ -488,6 +488,45 @@ fallback to `markdown-follow-thing-at-point' on failure"
     (when (equal org-link-translation-function 'toc-org-unhrefify)
       (setq org-link-translation-function nil))))
 
+;;;###autoload
+(defun toc-org-show-toc-window ()
+  "Show the table of contents of the current buffer in a side window.
+The TOC is displayed in a dedicated buffer with `org-mode' enabled,
+allowing navigation via `org-open-at-point' (\\[org-open-at-point])."
+  (interactive)
+  (let* ((source-buf  (current-buffer))
+         (source-file (buffer-file-name source-buf))
+         (markdown-p  (derived-mode-p 'markdown-mode))
+         (raw-toc     (toc-org-flush-subheadings
+                       (toc-org-raw-toc markdown-p)
+                       toc-org-max-depth))
+         (win-buf     (get-buffer-create "*org-toc*")))
+    (if (string-empty-p (string-trim raw-toc))
+        (message "toc-org: No :toc: heading found in this buffer.")
+      (with-current-buffer win-buf
+        (let ((inhibit-read-only t))
+          (erase-buffer)
+          (dolist (line (split-string raw-toc "\n" t))
+            (when (string-match "^\\(\\*+\\)[ \t]+\\(.*\\)" line)
+              (let* ((depth  (1- (length (match-string 1 line))))
+                     (title  (match-string 2 line))
+                     (indent (make-string (* 2 depth) ?\s)))
+                (insert indent "- "
+                        (format "[[file:%s::*%s][%s]]"
+                                source-file title title)
+                        "\n"))))
+          (org-mode)
+          (setq buffer-read-only t)
+          (goto-char (point-min))
+          (setq-local header-line-format
+                      (format " TOC - %s" (buffer-name source-buf)))))
+      (display-buffer
+       win-buf
+       '(display-buffer-in-side-window
+         (side         . left)
+         (window-width . 35)
+         (slot         . 0))))))
+
 ;; Local Variables:
 ;; compile-command: "emacs -batch -l ert -l toc-org.el -l toc-org-test.el -f ert-run-tests-batch-and-exit && emacs -batch -f batch-byte-compile toc-org.el 2>&1 | sed -n '/Warning\|Error/p' | xargs -r ls"
 ;; End:

--- a/toc-org.el
+++ b/toc-org.el
@@ -143,7 +143,7 @@ size (e.g. 0.3 for 30%)."
   "Name of the buffer used for the TOC navigation pane.")
 
 (defvar-local toc-org--toc-buffer nil
-  "TOC side window buffer associated with this buffer.")
+  "TOC navigation pane buffer associated with this buffer.")
 
 (defun toc-org-raw-toc (markdown-syntax-p)
   "Return the \"raw\" table of contents of the current file,
@@ -520,7 +520,8 @@ fallback to `markdown-follow-thing-at-point' on failure"
       (setq org-link-translation-function nil))))
 
 (defun toc-org--effective-max-depth ()
-  "Return the max depth for the TOC: from the :TOC_N: tag if present, else `toc-org-max-depth'."
+  "Return the effective TOC max depth.
+Uses the depth from the :TOC_N: tag if present, else `toc-org-max-depth'."
   (save-excursion
     (goto-char (point-min))
     (let* ((case-fold-search t)
@@ -530,7 +531,7 @@ fallback to `markdown-follow-thing-at-point' on failure"
             (if tag (- (aref tag 1) ?0) toc-org-max-depth))
         toc-org-max-depth))))
 
-(defun toc-org--close-toc-window ()
+(defun toc-org--close-toc-pane ()
   "Close TOC side windows whose source buffers are no longer visible."
   (let ((any-toc-p nil))
     (dolist (buf (buffer-list))
@@ -544,9 +545,9 @@ fallback to `markdown-follow-thing-at-point' on failure"
               (setq toc-org--toc-buffer nil)
               (remove-hook 'after-save-hook #'toc-org--refresh-navigation-pane t))))))
     (unless any-toc-p
-      (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-window))))
+      (remove-hook 'buffer-list-update-hook #'toc-org--close-toc-pane))))
 
-(defun toc-org--close-toc-window-on-kill ()
+(defun toc-org--close-toc-pane-on-kill ()
   "Close the TOC side window when the source buffer is killed."
   (when (and toc-org--toc-buffer
              (buffer-live-p toc-org--toc-buffer))
@@ -554,7 +555,7 @@ fallback to `markdown-follow-thing-at-point' on failure"
     (setq toc-org--toc-buffer nil))
   (remove-hook 'after-save-hook #'toc-org--refresh-navigation-pane t))
 
-(defun toc-org--refresh-navigation-pane ()
+(defun toc-org--refresh-navigation-pane (&optional max-depth)
   "Refresh the TOC navigation pane content for the current source buffer."
   (when (and toc-org--toc-buffer
              (buffer-live-p toc-org--toc-buffer))
@@ -563,7 +564,7 @@ fallback to `markdown-follow-thing-at-point' on failure"
            (markdown-p   (derived-mode-p 'markdown-mode))
            (raw-toc      (toc-org-flush-subheadings
                           (toc-org-raw-toc markdown-p)
-                          (toc-org--effective-max-depth)))
+                          (or max-depth (toc-org--effective-max-depth))))
            (toc-buf      toc-org--toc-buffer)
            (win          (get-buffer-window toc-buf))
            (saved-point  (when win (window-point win))))
@@ -596,14 +597,14 @@ fallback to `markdown-follow-thing-at-point' on failure"
               (set-window-point win (min saved-point (point-max)))
             (goto-char (point-min))))))))
 
-(defun toc-org--goto-current-heading ()
+(defun toc-org--goto-current-heading (&optional max-depth)
   "In the TOC buffer, position point at the entry for the heading at point."
   (when (and toc-org--toc-buffer
              (buffer-live-p toc-org--toc-buffer))
     (let* ((toc-buf    toc-org--toc-buffer)
            (markdown-p (derived-mode-p 'markdown-mode))
            (heading-re (if markdown-p "^\\(#+\\)[ \t]+" "^\\(\\*+\\)[ \t]+"))
-           (max-depth  (toc-org--effective-max-depth))
+           (max-depth  (or max-depth (toc-org--effective-max-depth)))
            (line-num
             (save-excursion
               (end-of-line)
@@ -627,17 +628,17 @@ fallback to `markdown-follow-thing-at-point' on failure"
 
 ;;;###autoload
 (defun toc-org-navigation-pane ()
-  "Show the table of contents of the current buffer in a side window.
+  "Show the table of contents of the current buffer as a side pane.
 
-Works as a toggle: calling it again closes the window.
+Works as a toggle: calling it again closes the pane.
 
 The TOC buffer is read-only with these single-letter shortcuts:
   n / p   next / previous line
   f / b   forward / backward character
-  k       close the window
+  k       close the pane
   RET     follow the link on the current line
 
-Customize `toc-org-side-window-side' to set which side the window
+Customize `toc-org-side-window-side' to set which side the pane
 appears on (left, right, top, or bottom).  Customize
 `toc-org-side-window-size' to set the width or height: an integer
 for a fixed number of columns/lines, or a float (0.0–1.0) for a
@@ -651,28 +652,22 @@ fraction of the frame size."
          (get-buffer-window toc-org--toc-buffer))
     (kill-buffer toc-org--toc-buffer)
     (setq toc-org--toc-buffer nil)
-    (remove-hook 'after-save-hook #'toc-org--refresh-navigation-pane t))
+    (remove-hook 'kill-buffer-hook #'toc-org--close-toc-pane-on-kill t)
+    (remove-hook 'after-save-hook  #'toc-org--refresh-navigation-pane t))
    (t
     (let* ((source-buf  (current-buffer))
            (source-file (buffer-file-name source-buf))
-           (markdown-p  (derived-mode-p 'markdown-mode))
-           (raw-toc     (toc-org-flush-subheadings
-                         (toc-org-raw-toc markdown-p)
-                         (toc-org--effective-max-depth)))
+           (max-depth   (toc-org--effective-max-depth))
            (win-buf     (get-buffer-create toc-org-navigation-pane-buffer-name)))
-      (cond
-       ((not source-file)
-        (kill-buffer win-buf)
-        (message "toc-org: Buffer is not visiting a file."))
-       ((string-empty-p (string-trim raw-toc))
-        (kill-buffer win-buf)
-        (message "toc-org: No headings found in this buffer."))
-       (t
+      (if (not source-file)
+          (progn
+            (kill-buffer win-buf)
+            (message "toc-org: Buffer is not visiting a file."))
         (with-current-buffer win-buf
           (org-mode)
           (display-line-numbers-mode -1)
           (setq-local mode-line-format nil)
-          (setq buffer-read-only t)
+          (setq-local buffer-read-only t)
           (setq-local header-line-format
                       (format " Table of Contents - %s" (buffer-name source-buf)))
           (let ((map (make-sparse-keymap)))
@@ -686,19 +681,26 @@ fraction of the frame size."
             (use-local-map map)))
         (with-current-buffer source-buf
           (setq toc-org--toc-buffer win-buf)
-          (add-hook 'kill-buffer-hook        #'toc-org--close-toc-window-on-kill nil t)
+          (add-hook 'kill-buffer-hook        #'toc-org--close-toc-pane-on-kill nil t)
           (add-hook 'after-save-hook         #'toc-org--refresh-navigation-pane nil t)
-          (add-hook 'buffer-list-update-hook #'toc-org--close-toc-window)
-          (toc-org--refresh-navigation-pane)
-          (toc-org--goto-current-heading))
-        (select-window
-         (display-buffer
-          win-buf
-          (cons 'display-buffer-in-side-window
-                (list (cons 'side          toc-org-side-window-side)
-                      (cons 'window-width  toc-org-side-window-size)
-                      (cons 'window-height toc-org-side-window-size)
-                      '(slot . 0)))))))))))
+          (add-hook 'buffer-list-update-hook #'toc-org--close-toc-pane)
+          (toc-org--refresh-navigation-pane max-depth))
+        (if (with-current-buffer win-buf (zerop (buffer-size)))
+            (progn
+              (kill-buffer win-buf)
+              (setq toc-org--toc-buffer nil)
+              (remove-hook 'kill-buffer-hook #'toc-org--close-toc-pane-on-kill t)
+              (remove-hook 'after-save-hook  #'toc-org--refresh-navigation-pane t)
+              (message "toc-org: No headings found in this buffer."))
+          (toc-org--goto-current-heading max-depth)
+          (select-window
+           (display-buffer
+            win-buf
+            (cons 'display-buffer-in-side-window
+                  (list (cons 'side          toc-org-side-window-side)
+                        (cons 'window-width  toc-org-side-window-size)
+                        (cons 'window-height toc-org-side-window-size)
+                        '(slot . 0)))))))))))
 
 ;; Local Variables:
 ;; compile-command: "emacs -batch -l ert -l toc-org.el -l toc-org-test.el -f ert-run-tests-batch-and-exit && emacs -batch -f batch-byte-compile toc-org.el 2>&1 | sed -n '/Warning\|Error/p' | xargs -r ls"

--- a/toc-org.el
+++ b/toc-org.el
@@ -578,7 +578,10 @@ Uses the depth from the :TOC_N: tag if present, else `toc-org-max-depth'."
            (markdown-p   (derived-mode-p 'markdown-mode))
            (raw-toc      (toc-org-flush-subheadings
                           (toc-org-raw-toc markdown-p)
-                          (or max-depth (toc-org--effective-max-depth))))
+                          (or max-depth
+                              (with-current-buffer toc-org--toc-buffer
+                                                   toc-org--nav-max-depth)
+                              (toc-org--effective-max-depth))))
            (win          (get-buffer-window toc-buf))
            (saved-point  (when win (window-point win))))
       (with-current-buffer toc-buf

--- a/toc-org.el
+++ b/toc-org.el
@@ -596,8 +596,20 @@ fallback to `markdown-follow-thing-at-point' on failure"
 ;;;###autoload
 (defun toc-org-navigation-window ()
   "Show the table of contents of the current buffer in a side window.
-The TOC is displayed in a dedicated buffer with `org-mode' enabled,
-allowing navigation via `org-open-at-point' (\\[org-open-at-point])."
+
+Works as a toggle: calling it again closes the window.
+
+The TOC buffer is read-only with these single-letter shortcuts:
+  n / p   next / previous line
+  f / b   forward / backward character
+  k       close the window
+  RET     follow the link on the current line
+
+Customize `toc-org-side-window-side' to set which side the window
+appears on (left, right, top, or bottom).  Customize
+`toc-org-side-window-size' to set the width or height: an integer
+for a fixed number of columns/lines, or a float (0.0–1.0) for a
+fraction of the frame size."
   (interactive)
 
    (if (string= (buffer-name) toc-org-navigation-window-buffer-name)


### PR DESCRIPTION
## Overview
This PR introduces a new command `toc-org-show-toc-window` that allows users to view the Table of Contents in a dedicated side window. 

## Demo
![toc-org-side-window-demo](https://github-production-user-asset-6210df.s3.amazonaws.com/215027645/591403334-d0431bc4-458b-477b-b680-f77a34014160.gif?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20260512%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20260512T232232Z&X-Amz-Expires=300&X-Amz-Signature=5e986cd3a4efc113d4adf22447fee83831f5cacc0babdaef17d463bcd42b0b06&X-Amz-SignedHeaders=host&response-content-type=image%2Fgif)

## Documentation
Updated the README with a new section "TOC Side Window" explaining how to use and customize this feature.